### PR TITLE
support SpecialFunctions 2.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ FastTransforms = "0.12, 0.13"
 FillArrays = "0.11, 0.12"
 IntervalSets = "0.5"
 Reexport = "0.2, 1"
-SpecialFunctions = "0.10, 1.0"
+SpecialFunctions = "0.10, 1.0, 2"
 julia = "1.5"
 
 [extras]


### PR DESCRIPTION
The only breaking change in SpecialFunctions 2.0 [was deleting](https://github.com/JuliaMath/SpecialFunctions.jl/pull/297) the `factorial(x::Real) = gamma(x+1)` function, and since you don't use `factorial` this shouldn't affect you.