### PR TITLE
Handle empty coeff vectors in Multiplication for Ultraspherical spaces

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.4.7"
+version = "0.4.8"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
+++ b/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
@@ -31,8 +31,11 @@ function Multiplication(f::Fun{C},sp::Ultraspherical{Int}) where C<:Chebyshev
     if order(sp) == 1
         cfs = f.coefficients
         MultiplicationWrapper(f,
-            SpaceOperator(SymToeplitzOperator(cfs/2) +
-                                HankelOperator(view(cfs,3:length(cfs))/(-2)),
+            SpaceOperator(
+                length(cfs) > 0 ?
+                    SymToeplitzOperator(cfs/2) +
+                        HankelOperator(view(cfs,3:length(cfs))/(-2)) :
+                    HankelOperator(view(cfs,3:length(cfs))/(-2)),
                           sp,sp))
 
     else

--- a/test/OperatorTest.jl
+++ b/test/OperatorTest.jl
@@ -268,6 +268,13 @@ import ApproxFunOrthogonalPolynomials: JacobiZ
         @test exp(-M).f == Multiplication(exp(-x), Chebyshev()).f
         @test (M/3).f == (3\M).f == Multiplication(x/3, Chebyshev()).f
         @test (M*3).f == (3*M).f == Multiplication(x*3, Chebyshev()).f
+
+        # test for Fun with an empty coefficients vector
+        v1 = Fun(Chebyshev(), Float64[])
+        v2 = Fun(Chebyshev(), Float64[0.0])
+        sp = Ultraspherical(1)
+        # the matrix representations should be identical
+        @test Multiplication(v1, sp)[1:4, 1:4] == Multiplication(v2, sp)[1:4, 1:4]
     end
 
     @testset "lastindex" begin


### PR DESCRIPTION
On master

```julia
julia> v1 = Fun(Chebyshev(), Float64[])
(::Fun{Chebyshev{ChebyshevInterval{Float64}, Float64}, Float64, Vector{Float64}}) (generic function with 1 method)

julia> sp = Ultraspherical(1)
Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}(1, -1.0..1.0 (Chebyshev))

julia> Multiplication(v1, sp)
ERROR: BoundsError: attempt to access 0-element Vector{Float64} at index [1]
Stacktrace:
 [1] getindex
   @ ./array.jl:861 [inlined]
 [2] SymToeplitzOperator(V::Vector{Float64})
   @ ApproxFunBase ~/.julia/packages/ApproxFunBase/fvVRN/src/Operators/banded/ToeplitzOperator.jl:25
 [3] Multiplication(f::Fun{Chebyshev{ChebyshevInterval{Float64}, Float64}, Float64, Vector{Float64}}, sp::Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64})
   @ ApproxFunOrthogonalPolynomials ~/Dropbox/PostDoc/RossbyWaves/RossbyWaveSpectrum.jl/dev/ApproxFunOrthogonalPolynomials/src/Spaces/Ultraspherical/UltrasphericalOperators.jl:33
 [4] top-level scope
   @ REPL[14]:1
```

This PR
```julia
julia> Multiplication(v1, sp)
ApproxFunBase.MultiplicationWrapper{Chebyshev{ChebyshevInterval{Float64}, Float64}, Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}, ApproxFunBase.SpaceOperator{HankelOperator{Float64}, Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}, Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}, Float64}, Float64}(Fun{Chebyshev{ChebyshevInterval{Float64}, Float64}, Float64, Vector{Float64}}(Chebyshev{ChebyshevInterval{Float64}, Float64}(-1.0..1.0 (Chebyshev)), Float64[]), ApproxFunBase.SpaceOperator{HankelOperator{Float64}, Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}, Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}, Float64}(HankelOperator{Float64}(Float64[]), Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}(1, -1.0..1.0 (Chebyshev)), Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}(1, -1.0..1.0 (Chebyshev))))

julia> Multiplication(v1, sp)[1:4, 1:4]
4×4 BandedMatrix{Float64} with bandwidths (0, 0):
 0.0   ⋅    ⋅    ⋅ 
  ⋅   0.0   ⋅    ⋅ 
  ⋅    ⋅   0.0   ⋅ 
  ⋅    ⋅    ⋅   0.0
```