### PR TITLE
Inplace `Chebyshev` transform

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.4.10"
+version = "0.4.11"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Spaces/Chebyshev/Chebyshev.jl
+++ b/src/Spaces/Chebyshev/Chebyshev.jl
@@ -72,6 +72,8 @@ transform(::Chebyshev,vals::AbstractVector,plan) = plan*vals
 itransform(::Chebyshev,cfs::AbstractVector,plan) = plan*cfs
 plan_transform(::Chebyshev,vals::AbstractVector) = plan_chebyshevtransform(vals)
 plan_itransform(::Chebyshev,cfs::AbstractVector) = plan_ichebyshevtransform(cfs)
+plan_transform!(::Chebyshev, vals::AbstractVector) = plan_chebyshevtransform!(vals)
+plan_itransform!(::Chebyshev, cfs::AbstractVector) = plan_ichebyshevtransform!(cfs)
 
 ## Evaluation
 

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -1,6 +1,6 @@
 using ApproxFunOrthogonalPolynomials, ApproxFunBase, LinearAlgebra, Test
-    import ApproxFunBase: testspace, recA, recB, recC
-    import ApproxFunOrthogonalPolynomials: forwardrecurrence
+import ApproxFunBase: testspace, recA, recB, recC, transform!, itransform!
+import ApproxFunOrthogonalPolynomials: forwardrecurrence
 
 @testset "Chebyshev" begin
     @testset "Forward recurrence" begin
@@ -207,5 +207,15 @@ using ApproxFunOrthogonalPolynomials, ApproxFunBase, LinearAlgebra, Test
         S=Chebyshev()
         @test S.a==-0.5
         @test S.b==-0.5
+    end
+
+    @testset "inplace transform" begin
+        for v in Any[rand(10), rand(ComplexF64, 10)]
+            v2 = copy(v)
+            transform!(Chebyshev(), v)
+            @test transform(Chebyshev(), v2) == v
+            itransform!(Chebyshev(), v)
+            @test v2 ≈ v
+        end
     end
 end

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -210,12 +210,14 @@ import ApproxFunOrthogonalPolynomials: forwardrecurrence
     end
 
     @testset "inplace transform" begin
-        for v in Any[rand(10), rand(ComplexF64, 10)]
-            v2 = copy(v)
-            transform!(Chebyshev(), v)
-            @test transform(Chebyshev(), v2) == v
-            itransform!(Chebyshev(), v)
-            @test v2 ≈ v
+        for T in [Float32, Float64, BigFloat]
+            for v in Any[rand(T, 10), rand(complex(T), 10)]
+                v2 = copy(v)
+                transform!(Chebyshev(), v)
+                @test transform(Chebyshev(), v2) == v
+                itransform!(Chebyshev(), v)
+                @test v2 ≈ v
+            end
         end
     end
 end


### PR DESCRIPTION
These are supported by `FastTransforms`, so we may add these here. After this, the following works:
```julia
julia> v = rand(10);

julia> v2 = copy(v);

julia> transform!(Chebyshev(), v);

julia> transform(Chebyshev(), v2) == v
true
```