### PR TITLE
Inference in `Chebyshev`/`Ultraspherical` conversion

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.4.14"
+version = "0.4.15"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
+++ b/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
@@ -123,7 +123,7 @@ function Conversion(A::Chebyshev,B::Ultraspherical)
     else
         d=domain(A)
         US=Ultraspherical(order(B)-1,d)
-        ConversionWrapper(TimesOperator(Conversion(US,B),
+        ConversionWrapper(TimesOperator(ConcreteConversion(US,B),
                                         Conversion(Chebyshev(d),US)))
     end
 end
@@ -148,7 +148,7 @@ function Conversion(A::Ultraspherical,B::Ultraspherical)
         ConcreteConversion(A,B)
     elseif b-a > 1
         d=domain(A)
-        ConversionWrapper(TimesOperator(Conversion(Ultraspherical(b-1,d),B),
+        ConversionWrapper(TimesOperator(ConcreteConversion(Ultraspherical(b-1,d),B),
                                         Conversion(A,Ultraspherical(b-1,d))))
     else
         throw(ArgumentError("Cannot convert from $A to $B"))

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -9,5 +9,24 @@ import ApproxFunOrthogonalPolynomials: jacobip
         # Tests whether invalid/unimplemented arguments correctly throws ArgumentError
         @test_throws ArgumentError Conversion(Ultraspherical(2), Ultraspherical(1))
         @test_throws ArgumentError Conversion(Ultraspherical(3), Ultraspherical(1.9))
+
+        # Conversions from Chebyshev to Ultraspherical should lead to a small union of types
+        Tallowed = Union{
+            ApproxFunBase.ConcreteConversion{
+                Chebyshev{ChebyshevInterval{Float64}, Float64},
+                Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}, Float64},
+            ApproxFunBase.ConversionWrapper{TimesOperator{Float64, Tuple{Int64, Int64}}, Float64}};
+        @inferred Tallowed Conversion(Chebyshev(), Ultraspherical(1));
+        @inferred Tallowed Conversion(Chebyshev(), Ultraspherical(2));
+        # Conversions between Ultraspherical should lead to a small union of types
+        Tallowed = Union{
+            ApproxFunBase.ConcreteConversion{
+                Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64},
+                Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}, Float64},
+            ApproxFunBase.ConversionWrapper{
+                ConstantOperator{Float64,
+                    Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}}, Float64},
+                    ApproxFunBase.ConversionWrapper{TimesOperator{Float64, Tuple{Int64, Int64}}, Float64}};
+        @inferred Tallowed Conversion(Ultraspherical(1), Ultraspherical(2));
     end
 end


### PR DESCRIPTION
This improves the type inference, as the result becomes a union of concrete types.
Master:
```julia
julia> @code_warntype Conversion(Chebyshev(), Ultraspherical(1))
MethodInstance for Conversion(::Chebyshev{ChebyshevInterval{Float64}, Float64}, ::Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64})
  from Conversion(A::Chebyshev, B::Ultraspherical) in ApproxFunOrthogonalPolynomials at /home/jishnu/Dropbox/JuliaPackages/ApproxFunOrthogonalPolynomials.jl/src/Spaces/Ultraspherical/UltrasphericalOperators.jl:120
Arguments
  #self#::Type{Conversion}
  A::Core.Const(Chebyshev())
  B::Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}
Locals
  US::Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}
  d::ChebyshevInterval{Float64}
Body::Union{ApproxFunBase.ConcreteConversion{Chebyshev{ChebyshevInterval{Float64}, Float64}, Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}, Float64}, ApproxFunBase.ConversionWrapper}
```
This PR:
```julia
julia> @code_warntype Conversion(Chebyshev(), Ultraspherical(1))
MethodInstance for Conversion(::Chebyshev{ChebyshevInterval{Float64}, Float64}, ::Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64})
  from Conversion(A::Chebyshev, B::Ultraspherical) in ApproxFunOrthogonalPolynomials at /home/jishnu/Dropbox/JuliaPackages/ApproxFunOrthogonalPolynomials.jl/src/Spaces/Ultraspherical/UltrasphericalOperators.jl:120
Arguments
  #self#::Type{Conversion}
  A::Core.Const(Chebyshev())
  B::Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}
Locals
  US::Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}
  d::ChebyshevInterval{Float64}
Body::Union{ApproxFunBase.ConcreteConversion{Chebyshev{ChebyshevInterval{Float64}, Float64}, Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}, Float64}, ApproxFunBase.ConversionWrapper{TimesOperator{Float64, Tuple{Int64, Int64}}, Float64}}
```
Tests are not ideal here, as they will pass on master as well, but at least they'll prevent against egregious regressions.