### PR TITLE
`ConcreteConversion` in `Chebyshev`-`Jacobi`

### DIFF
--- a/src/Spaces/Jacobi/JacobiOperators.jl
+++ b/src/Spaces/Jacobi/JacobiOperators.jl
@@ -294,14 +294,14 @@ function Conversion(A::Jacobi,B::Chebyshev)
     elseif A.a == A.b == 0
         ConversionWrapper(
             SpaceOperator(
-                Conversion(Ultraspherical(1//2),B),
+                ConcreteConversion(Ultraspherical(1//2),B),
                 A,B))
     elseif A.a == A.b
         US = Ultraspherical(A)
-        ConversionWrapper(Conversion(US,B)*Conversion(A,US))
+        ConversionWrapper(Conversion(US,B)*ConcreteConversion(A,US))
     else
         J = Jacobi(B)
-        Conversion(J,B)*Conversion(A,J)
+        ConcreteConversion(J,B)*Conversion(A,J)
     end
 end
 
@@ -311,21 +311,22 @@ function Conversion(A::Chebyshev,B::Jacobi)
     elseif B.a == B.b == 0
         ConversionWrapper(
             SpaceOperator(
-                Conversion(A,Ultraspherical(1//2,domain(B))),
+                ConcreteConversion(A,Ultraspherical(1//2,domain(B))),
                 A,B))
     elseif B.a == B.b
         US = Ultraspherical(B)
-        ConversionWrapper(Conversion(US,B)*Conversion(A,US))
+        ConcreteConversion(US,B) * Conversion(A,US)
     else
         J = Jacobi(A)
-        Conversion(J,B)*Conversion(A,J)
+        Conversion(J,B)*ConcreteConversion(A,J)
     end
 end
 
 
 function Conversion(A::Jacobi,B::Ultraspherical)
     if A.a == A.b == -0.5
-        ConversionWrapper(Conversion(Chebyshev(domain(A)),B)*Conversion(A,Chebyshev(domain(A))))
+        ConversionWrapper(Conversion(Chebyshev(domain(A)),B)*
+            ConcreteConversion(A,Chebyshev(domain(A))))
     elseif A.a == A.b == order(B)-0.5
         ConcreteConversion(A,B)
     elseif A.a == A.b == 0
@@ -335,16 +336,17 @@ function Conversion(A::Jacobi,B::Ultraspherical)
                 A,B))
     elseif A.a == A.b
         US = Ultraspherical(A)
-        ConversionWrapper(Conversion(US,B)*Conversion(A,US))
+        ConversionWrapper(Conversion(US,B)*ConcreteConversion(A,US))
     else
         J = Jacobi(B)
-        Conversion(J,B)*Conversion(A,J)
+        ConcreteConversion(J,B)*Conversion(A,J)
     end
 end
 
 function Conversion(A::Ultraspherical,B::Jacobi)
     if B.a == B.b == -0.5
-        ConversionWrapper(Conversion(Chebyshev(domain(A)),B)*Conversion(A,Chebyshev(domain(A))))
+        ConversionWrapper(ConcreteConversion(Chebyshev(domain(A)),B)*
+            Conversion(A,Chebyshev(domain(A))))
     elseif B.a == B.b == order(A)-0.5
         ConcreteConversion(A,B)
     elseif B.a == B.b == 0
@@ -354,10 +356,10 @@ function Conversion(A::Ultraspherical,B::Jacobi)
                 A,B))
     elseif B.a == B.b
         US = Ultraspherical(B)
-        ConversionWrapper(Conversion(US,B)*Conversion(A,US))
+        ConversionWrapper(ConcreteConversion(US,B)*Conversion(A,US))
     else
         J = Jacobi(A)
-        Conversion(J,B)*Conversion(A,J)
+        Conversion(J,B)*ConcreteConversion(A,J)
     end
 end
 

--- a/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
+++ b/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
@@ -123,8 +123,8 @@ function Conversion(A::Chebyshev,B::Ultraspherical)
     else
         d=domain(A)
         US=Ultraspherical(order(B)-1,d)
-        ConversionWrapper(TimesOperator(ConcreteConversion(US,B),
-                                        Conversion(Chebyshev(d),US)))
+        ConversionWrapper(TimesOperator(
+            ConcreteConversion(US,B), Conversion(A,US)))
     end
 end
 
@@ -148,8 +148,9 @@ function Conversion(A::Ultraspherical,B::Ultraspherical)
         ConcreteConversion(A,B)
     elseif b-a > 1
         d=domain(A)
-        ConversionWrapper(TimesOperator(ConcreteConversion(Ultraspherical(b-1,d),B),
-                                        Conversion(A,Ultraspherical(b-1,d))))
+        US=Ultraspherical(b-1,d)
+        ConversionWrapper(TimesOperator(
+            ConcreteConversion(US,B), Conversion(A,US)))
     else
         throw(ArgumentError("Cannot convert from $A to $B"))
     end

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -56,12 +56,18 @@ import ApproxFunOrthogonalPolynomials: jacobip
             end
         end
 
-        f = Fun(x->x^2, Chebyshev())
-        C = Chebyshev()
-        @testset for J = Any[Jacobi(-0.5, -0.5), Legendre(),
-                            Jacobi(0.5, 0.5), Jacobi(2.5, 1.5)]
-
-            @test Conversion(C, J) * f ≈ Fun(f, J)
+        @testset for d in [-1..1, 0..1]
+            f = Fun(x->x^2, Chebyshev(d))
+            C = space(f)
+            for J1 = Any[Jacobi(-0.5, -0.5, d), Legendre(d),
+                            Jacobi(0.5, 0.5, d), Jacobi(2.5, 1.5, d)]
+                for J in [J1, NormalizedPolynomialSpace(J1)]
+                    g = Fun(f, J)
+                    if !any(isnan, coefficients(g))
+                        @test Conversion(C, J) * f ≈ g
+                    end
+                end
+            end
         end
     end
 
@@ -69,16 +75,14 @@ import ApproxFunOrthogonalPolynomials: jacobip
         D=Derivative(Jacobi(0.,1.,Segment(1.,0.)))
         @time testbandedoperator(D)
 
-        f = Fun(x->x^2, Chebyshev())
-        C = Chebyshev()
-        @testset for J = Any[Jacobi(-0.5, -0.5), Legendre()]
-            if ApproxFunBase.hasconversion(C, J)
+        @testset for d in [-1..1, 0..1]
+            f = Fun(x->x^2, Chebyshev(d))
+            C = space(f)
+            for J = Any[Jacobi(-0.5, -0.5, d), Legendre(d)]
                 g = (Derivative(J) * Conversion(C, J)) * f
                 h = Derivative(C) * f
                 @test g ≈ h
-            end
 
-            if ApproxFunBase.hasconversion(J, C)
                 g = (Derivative(C) * Conversion(J, C)) * f
                 h = Derivative(J) * f
                 @test g ≈ h

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -55,6 +55,14 @@ import ApproxFunOrthogonalPolynomials: jacobip
                 end
             end
         end
+
+        f = Fun(x->x^2, Chebyshev())
+        C = Chebyshev()
+        @testset for J = Any[Jacobi(-0.5, -0.5), Legendre(),
+                            Jacobi(0.5, 0.5), Jacobi(2.5, 1.5)]
+
+            @test Conversion(C, J) * f ≈ Fun(f, J)
+        end
     end
 
     @testset "Derivative" begin

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -60,6 +60,22 @@ import ApproxFunOrthogonalPolynomials: jacobip
     @testset "Derivative" begin
         D=Derivative(Jacobi(0.,1.,Segment(1.,0.)))
         @time testbandedoperator(D)
+
+        f = Fun(x->x^2, Chebyshev())
+        C = Chebyshev()
+        @testset for J = Any[Jacobi(-0.5, -0.5), Legendre()]
+            if ApproxFunBase.hasconversion(C, J)
+                g = (Derivative(J) * Conversion(C, J)) * f
+                h = Derivative(C) * f
+                @test g ≈ h
+            end
+
+            if ApproxFunBase.hasconversion(J, C)
+                g = (Derivative(C) * Conversion(J, C)) * f
+                h = Derivative(J) * f
+                @test g ≈ h
+            end
+        end
     end
 
     @testset "identity Fun for interval domains" begin


### PR DESCRIPTION
This provides a slight improvement
```julia
julia> A = Chebyshev(); B = Jacobi(1,1);

julia> @btime Conversion($(Ref(A))[], $(Ref(B))[]);
  2.444 μs (32 allocations: 1.12 KiB) # master
  2.322 μs (31 allocations: 1.09 KiB) # PR
```