### PR TITLE
Identity Fun in normalized Polynomial spaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
         version:
           - '1.5'
           - '1'
-          - '^1.8.0-0'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.4.16"
+version = "0.4.17"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -367,6 +367,15 @@ function Conversion(L::S, M::NormalizedPolynomialSpace{S}) where S<:PolynomialSp
     end
 end
 
+function Fun(::typeof(identity), S::NormalizedPolynomialSpace)
+    C = canonicalspace(S)
+    f = Fun(identity, C)
+    coeffs = coefficients(f)
+    CS = ConcreteConversion(C, S)
+    ApproxFunBase.mul_coefficients!(CS, coeffs)
+    Fun(S, coeffs)
+end
+
 bandwidths(C::ConcreteConversion{NormalizedPolynomialSpace{S,D,R},S}) where {S,D,R} = (0, 0)
 bandwidths(C::ConcreteConversion{S,NormalizedPolynomialSpace{S,D,R}}) where {S,D,R} = (0, 0)
 

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -222,17 +222,18 @@ import ApproxFunOrthogonalPolynomials: forwardrecurrence
     end
 
     @testset "Normalized space" begin
-        f = x -> 3x^3 + 5x^2 + 2
-        for dt in Any[(), (0..1,)]
-            S = Chebyshev(dt...)
-            NS = NormalizedPolynomialSpace(S)
-            f = Fun(f, S)
-            g = Fun(f, NS)
-            @test space(g) == NS
-            d = domain(f)
-            r = range(leftendpoint(d), rightendpoint(d), length=10)
-            for x in r
-                @test f(x) ≈ g(x)
+        for f in Any[x -> 3x^3 + 5x^2 + 2, x->x, identity]
+            for dt in Any[(), (0..1,)]
+                S = Chebyshev(dt...)
+                NS = NormalizedPolynomialSpace(S)
+                f = Fun(f, S)
+                g = Fun(f, NS)
+                @test space(g) == NS
+                d = domain(f)
+                r = range(leftendpoint(d), rightendpoint(d), length=10)
+                for x in r
+                    @test f(x) ≈ g(x)
+                end
             end
         end
     end

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -230,7 +230,7 @@ import ApproxFunOrthogonalPolynomials: forwardrecurrence
             g = Fun(f, NS)
             @test space(g) == NS
             d = domain(f)
-            r = range(leftendpoint(d), rightendpoint(d), 10)
+            r = range(leftendpoint(d), rightendpoint(d), length=10)
             for x in r
                 @test f(x) ≈ g(x)
             end

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -232,7 +232,7 @@ import ApproxFunOrthogonalPolynomials: forwardrecurrence
                 d = domain(f)
                 r = range(leftendpoint(d), rightendpoint(d), length=10)
                 for x in r
-                    @test f(x) ≈ g(x)
+                    @test f(x) ≈ g(x) rtol=1e-7 atol=1e-14
                 end
             end
         end

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -226,13 +226,14 @@ import ApproxFunOrthogonalPolynomials: forwardrecurrence
             for dt in Any[(), (0..1,)]
                 S = Chebyshev(dt...)
                 NS = NormalizedPolynomialSpace(S)
-                f = Fun(f, S)
-                g = Fun(f, NS)
-                @test space(g) == NS
-                d = domain(f)
+
+                fS = Fun(f, S)
+                fNS = Fun(f, NS)
+                @test space(fNS) == NS
+                d = domain(fS)
                 r = range(leftendpoint(d), rightendpoint(d), length=10)
                 for x in r
-                    @test f(x) ≈ g(x) rtol=1e-7 atol=1e-14
+                    @test fS(x) ≈ fNS(x) rtol=1e-7 atol=1e-14
                 end
             end
         end

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -220,4 +220,20 @@ import ApproxFunOrthogonalPolynomials: forwardrecurrence
             end
         end
     end
+
+    @testset "Normalized space" begin
+        f = x -> 3x^3 + 5x^2 + 2
+        for dt in Any[(), (0..1,)]
+            S = Chebyshev(dt...)
+            NS = NormalizedPolynomialSpace(S)
+            f = Fun(f, S)
+            g = Fun(f, NS)
+            @test space(g) == NS
+            d = domain(f)
+            r = range(leftendpoint(d), rightendpoint(d), 10)
+            for x in r
+                @test f(x) ≈ g(x)
+            end
+        end
+    end
 end

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -297,4 +297,21 @@ import ApproxFunOrthogonalPolynomials: jacobip
         testbandedbelowoperator(C)
         @test norm(C*Fun(exp,Ultraspherical(1))-Fun(exp,Jacobi(0,0))) < 100eps()
     end
+
+    @testset "Normalized space" begin
+        f = x -> 3x^3 + 5x^2 + 2
+        for dt in Any[(), (0..1,)],
+                S in Any[Jacobi(1,1,dt...), Jacobi(0.5,1.5,dt...), Legendre(dt...), ]
+
+            NS = NormalizedPolynomialSpace(S)
+            f = Fun(f, S)
+            g = Fun(f, NS)
+            @test space(g) == NS
+            d = domain(f)
+            r = range(leftendpoint(d), rightendpoint(d), 10)
+            for x in r
+                @test f(x) ≈ g(x)
+            end
+        end
+    end
 end

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -299,18 +299,21 @@ import ApproxFunOrthogonalPolynomials: jacobip
     end
 
     @testset "Normalized space" begin
-        f = x -> 3x^3 + 5x^2 + 2
-        for dt in Any[(), (0..1,)],
-                S in Any[Jacobi(1,1,dt...), Jacobi(0.5,1.5,dt...), Legendre(dt...), ]
+        for f in Any[x -> 3x^3 + 5x^2 + 2, x->x, identity]
+            for dt in Any[(), (0..1,)],
+                    S in Any[Jacobi(1,1,dt...),
+                             Jacobi(0.5,1.5,dt...),
+                             Legendre(dt...), ]
 
-            NS = NormalizedPolynomialSpace(S)
-            f = Fun(f, S)
-            g = Fun(f, NS)
-            @test space(g) == NS
-            d = domain(f)
-            r = range(leftendpoint(d), rightendpoint(d), length=10)
-            for x in r
-                @test f(x) ≈ g(x)
+                NS = NormalizedPolynomialSpace(S)
+                f = Fun(f, S)
+                g = Fun(f, NS)
+                @test space(g) == NS
+                d = domain(f)
+                r = range(leftendpoint(d), rightendpoint(d), length=10)
+                for x in r
+                    @test f(x) ≈ g(x)
+                end
             end
         end
     end

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -312,7 +312,7 @@ import ApproxFunOrthogonalPolynomials: jacobip
                 d = domain(f)
                 r = range(leftendpoint(d), rightendpoint(d), length=10)
                 for x in r
-                    @test f(x) ≈ g(x)
+                    @test f(x) ≈ g(x) rtol=1e-7 atol=1e-14
                 end
             end
         end

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -308,7 +308,7 @@ import ApproxFunOrthogonalPolynomials: jacobip
             g = Fun(f, NS)
             @test space(g) == NS
             d = domain(f)
-            r = range(leftendpoint(d), rightendpoint(d), 10)
+            r = range(leftendpoint(d), rightendpoint(d), length=10)
             for x in r
                 @test f(x) ≈ g(x)
             end

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -306,13 +306,13 @@ import ApproxFunOrthogonalPolynomials: jacobip
                              Legendre(dt...), ]
 
                 NS = NormalizedPolynomialSpace(S)
-                f = Fun(f, S)
-                g = Fun(f, NS)
-                @test space(g) == NS
-                d = domain(f)
+                fS = Fun(f, S)
+                fNS = Fun(f, NS)
+                @test space(fNS) == NS
+                d = domain(fS)
                 r = range(leftendpoint(d), rightendpoint(d), length=10)
                 for x in r
-                    @test f(x) ≈ g(x) rtol=1e-7 atol=1e-14
+                    @test fS(x) ≈ fNS(x) rtol=1e-7 atol=1e-14
                 end
             end
         end

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -44,7 +44,7 @@ import ApproxFunOrthogonalPolynomials: jacobip
                 d = domain(f)
                 r = range(leftendpoint(d), rightendpoint(d), length=10)
                 for x in r
-                    @test f(x) ≈ g(x)
+                    @test f(x) ≈ g(x) rtol=1e-7 atol=1e-14
                 end
             end
         end

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -31,20 +31,21 @@ import ApproxFunOrthogonalPolynomials: jacobip
     end
 
     @testset "Normalized space" begin
-        f = x -> 3x^3 + 5x^2 + 2
-        for dt in Any[(), (0..1,)],
-                S in Any[Ultraspherical(1, dt...),
-                         Ultraspherical(0.5,dt...),
-                         Ultraspherical(3, dt...)]
+        for f in Any[x -> 3x^3 + 5x^2 + 2, x->x, identity]
+            for dt in Any[(), (0..1,)],
+                    S in Any[Ultraspherical(1, dt...),
+                             Ultraspherical(0.5,dt...),
+                             Ultraspherical(3, dt...)]
 
-            NS = NormalizedPolynomialSpace(S)
-            f = Fun(f, S)
-            g = Fun(f, NS)
-            @test space(g) == NS
-            d = domain(f)
-            r = range(leftendpoint(d), rightendpoint(d), length=10)
-            for x in r
-                @test f(x) ≈ g(x)
+                NS = NormalizedPolynomialSpace(S)
+                f = Fun(f, S)
+                g = Fun(f, NS)
+                @test space(g) == NS
+                d = domain(f)
+                r = range(leftendpoint(d), rightendpoint(d), length=10)
+                for x in r
+                    @test f(x) ≈ g(x)
+                end
             end
         end
     end

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -29,4 +29,23 @@ import ApproxFunOrthogonalPolynomials: jacobip
                     ApproxFunBase.ConversionWrapper{TimesOperator{Float64, Tuple{Int64, Int64}}, Float64}};
         @inferred Tallowed Conversion(Ultraspherical(1), Ultraspherical(2));
     end
+
+    @testset "Normalized space" begin
+        f = x -> 3x^3 + 5x^2 + 2
+        for dt in Any[(), (0..1,)],
+                S in Any[Ultraspherical(1, dt...),
+                         Ultraspherical(0.5,dt...),
+                         Ultraspherical(3, dt...)]
+
+            NS = NormalizedPolynomialSpace(S)
+            f = Fun(f, S)
+            g = Fun(f, NS)
+            @test space(g) == NS
+            d = domain(f)
+            r = range(leftendpoint(d), rightendpoint(d), 10)
+            for x in r
+                @test f(x) ≈ g(x)
+            end
+        end
+    end
 end

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -42,7 +42,7 @@ import ApproxFunOrthogonalPolynomials: jacobip
             g = Fun(f, NS)
             @test space(g) == NS
             d = domain(f)
-            r = range(leftendpoint(d), rightendpoint(d), 10)
+            r = range(leftendpoint(d), rightendpoint(d), length=10)
             for x in r
                 @test f(x) ≈ g(x)
             end

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -38,13 +38,13 @@ import ApproxFunOrthogonalPolynomials: jacobip
                              Ultraspherical(3, dt...)]
 
                 NS = NormalizedPolynomialSpace(S)
-                f = Fun(f, S)
-                g = Fun(f, NS)
-                @test space(g) == NS
-                d = domain(f)
+                fS = Fun(f, S)
+                fNS = Fun(f, NS)
+                @test space(fNS) == NS
+                d = domain(fS)
                 r = range(leftendpoint(d), rightendpoint(d), length=10)
                 for x in r
-                    @test f(x) ≈ g(x) rtol=1e-7 atol=1e-14
+                    @test fS(x) ≈ fNS(x) rtol=1e-7 atol=1e-14
                 end
             end
         end


### PR DESCRIPTION
This allows one to obtain
```julia
julia> f = Fun(NormalizedLegendre(0..1))
Fun(NormalizedLegendre(0..1), [0.5, 0.28867513459481287])

julia> f(0.4)
0.4
```
On master, this falls back to using `Chebyshev` as the space. Such a construction should work as long as the conversion between the canonical and the normalized space is defined.