### PR TITLE
`conversion_type` for normalized spaces and canonical

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -377,6 +377,10 @@ function Fun(::typeof(identity), S::NormalizedPolynomialSpace)
     Fun(S, coeffs)
 end
 
+function conversion_rule(a::NormalizedPolynomialSpace{S}, b::S) where S<:PolynomialSpace
+    domainscompatible(domain(a), domain(b)) ? a : NoSpace()
+end
+
 bandwidths(C::ConcreteConversion{NormalizedPolynomialSpace{S,D,R},S}) where {S,D,R} = (0, 0)
 bandwidths(C::ConcreteConversion{S,NormalizedPolynomialSpace{S,D,R}}) where {S,D,R} = (0, 0)
 

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -254,5 +254,12 @@ import ApproxFunOrthogonalPolynomials: forwardrecurrence
             @test f1 == f2
             @test D1 * f1 == D2 * f2
         end
+
+        @testset "space promotion" begin
+            s = NormalizedChebyshev()
+            f = (Derivative() + Fun(s)) * Fun(s)
+            g = ones(s) + Fun(s)^2
+            @test f ≈ g
+        end
     end
 end


### PR DESCRIPTION
The following works after this:
```julia
julia> (Derivative() + Fun(NormalizedChebyshev())) * Fun(NormalizedChebyshev())
Fun(Ultraspherical(1), [1.25, 0.0, 0.25])
```