### PR TITLE
Skip concurrent downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -9,6 +9,10 @@ on:
       - 'README.md'
       - '.github/workflows/TagBot.yml'
 
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: ${{ matrix.package.group }}/${{ matrix.package.repo }}/${{ matrix.julia-version }}


### PR DESCRIPTION
If a second commit happens while the first is running, this will cancel the first action and run the second one. This should help reduce the load on CI resources