### PR TITLE
Remove barysum

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -21,7 +21,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 AbstractFFTs = "0.5, 1"
-ApproxFunBase = "0.6.14"
+ApproxFunBase = "0.6.14 - 0.6.21"
 Aqua = "0.5"
 BandedMatrices = "0.16, 0.17"
 BlockArrays = "0.14, 0.15, 0.16"

--- a/src/bary.jl
+++ b/src/bary.jl
@@ -1,6 +1,6 @@
 ## Barycentric formula
 
-export bary,barysum
+export bary
 
 function bary(v::AbstractVector{Float64},pts::AbstractVector{Float64},x::Float64)
   n=length(v)

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -1,5 +1,3 @@
-
-
 # project to interval if we are not on the interview
 # TODO: need to work out how to set piecewise domain
 


### PR DESCRIPTION
Remove `barysum`, which is exported but undefined.

The compat limit on `ApproxFunBase` is keeping in mind the removal of the exported but undefined symbol `jumplocations` from it. Currently,
```julia
julia> @which jumplocations
ApproxFunOrthogonalPolynomials
```
so the export from `ApproxFunBase` is not having any impact. This will be removed in `ApproxFunBase` v0.6.22, which is technically not a breaking change, as the exported symbol isn't defined.