### PR TITLE
Update ApproxFunBase compat limit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 AbstractFFTs = "0.5, 1"
-ApproxFunBase = "0.6.14 - 0.6.21"
+ApproxFunBase = "0.6.14"
 Aqua = "0.5"
 BandedMatrices = "0.16, 0.17"
 BlockArrays = "0.14, 0.15, 0.16"


### PR DESCRIPTION
It's better to release a breaking version for `ApproxFunBase`, as we can't restrict the compat bounds on released versions of `ApproxFunOrthogonalPolynomials`.  In that case we don't need an upper limit for the 0.6 series.