### PR TITLE
Preserve bandwidth in multiplication

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.5.10"
+version = "0.5.11"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -435,5 +435,5 @@ end
 function Multiplication(f::Fun{U},sp::NormalizedPolynomialSpace) where U <: NormalizedPolynomialSpace
     csp = canonicalspace(f)
     fc = Conversion(space(f), csp)*f
-    MultiplicationWrapper(f,Conversion(csp,sp)*Multiplication(fc,csp)*Conversion(sp,csp))
+    Multiplication(fc, sp)
 end

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -421,8 +421,11 @@ hasconversion(a::NormalizedPolynomialSpace,b::NormalizedPolynomialSpace) = hasco
 
 
 function Multiplication(f::Fun{U},sp::NormalizedPolynomialSpace) where U <: PolynomialSpace
-    csp = space(f)
-    MultiplicationWrapper(f,Conversion(csp,sp)*Multiplication(f,csp)*Conversion(sp,csp))
+    fsp = space(f)
+    unnorm_sp = sp.space
+    O = Conversion(unnorm_sp,sp) *
+            Multiplication(f,unnorm_sp) * Conversion(sp, unnorm_sp)
+    MultiplicationWrapper(f, O)
 end
 
 function Multiplication(f::Fun{U},sp::PolynomialSpace) where U <: NormalizedPolynomialSpace

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -380,8 +380,14 @@ import ApproxFunOrthogonalPolynomials: jacobip
 
         @testset "Multiplication" begin
             xJ = Fun(NormalizedJacobi(1,1))
-            @test (Multiplication(Fun()) * xJ)(0.4) ≈ (0.4)^2
-            @test (Multiplication(Fun(NormalizedChebyshev())) * xJ)(0.4) ≈ (0.4)^2
+            xC = Fun()
+            xNC = Fun(NormalizedChebyshev())
+            @test (Multiplication(xC) * xJ)(0.4) ≈ (0.4)^2
+            @test (Multiplication(xNC) * xJ)(0.4) ≈ (0.4)^2
+            @test ApproxFunBase.isbanded(Multiplication(xC, NormalizedLegendre()))
+            @test ApproxFunBase.isbanded(Multiplication(xNC, NormalizedLegendre()))
+            @test ApproxFunBase.isbanded(Multiplication(xC, NormalizedJacobi(1,1)))
+            @test ApproxFunBase.isbanded(Multiplication(xNC, NormalizedJacobi(1,1)))
         end
     end
 

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -379,7 +379,9 @@ import ApproxFunOrthogonalPolynomials: jacobip
         end
 
         @testset "Multiplication" begin
-            @test (Multiplication(Fun()) * Fun(NormalizedJacobi(1,1)))(0.4) ≈ (0.4)^2
+            xJ = Fun(NormalizedJacobi(1,1))
+            @test (Multiplication(Fun()) * xJ)(0.4) ≈ (0.4)^2
+            @test (Multiplication(Fun(NormalizedChebyshev())) * xJ)(0.4) ≈ (0.4)^2
         end
     end
 

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -377,6 +377,10 @@ import ApproxFunOrthogonalPolynomials: jacobip
                 end
             end
         end
+
+        @testset "Multiplication" begin
+            @test (Multiplication(Fun()) * Fun(NormalizedJacobi(1,1)))(0.4) ≈ (0.4)^2
+        end
     end
 
     @testset "casting bug ApproxFun.jl#770" begin


### PR DESCRIPTION
This is an attempt to get the following to be banded:
```julia
julia> Multiplication(Fun(), NormalizedLegendre())
MultiplicationWrapper : NormalizedLegendre() → NormalizedLegendre()
 0.0      0.57735    ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
 0.57735  0.0       0.516398   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅       0.516398  0.0       0.507093   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅        ⋅        0.507093  0.0       0.503953   ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅        ⋅         ⋅        0.503953  0.0       0.502519   ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅        ⋅         ⋅         ⋅        0.502519  0.0       0.501745   ⋅         ⋅         ⋅        ⋅
  ⋅        ⋅         ⋅         ⋅         ⋅        0.501745  0.0       0.50128    ⋅         ⋅        ⋅
  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅        0.50128   0.0       0.500979   ⋅        ⋅
  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.500979  0.0       0.500773  ⋅
  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.500773  0.0       ⋱
  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋱        ⋱
```
This also fixes
```julia
julia> Multiplication(Fun(), NormalizedJacobi(1,1))
MultiplicationWrapper : NormalizedJacobi(1.0,1.0) → NormalizedJacobi(1.0,1.0)
 0.0       0.447214   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
 0.447214  0.0       0.478091   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅        0.478091  0.0       0.48795    ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅         ⋅        0.48795   0.0       0.492366   ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅         ⋅         ⋅        0.492366  0.0       0.494727   ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅         ⋅         ⋅         ⋅        0.494727  0.0       0.496139   ⋅         ⋅         ⋅        ⋅
  ⋅         ⋅         ⋅         ⋅         ⋅        0.496139  0.0       0.49705    ⋅         ⋅        ⋅
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.49705   0.0       0.497673   ⋅        ⋅
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.497673  0.0       0.498117  ⋅
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.498117  0.0       ⋱
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋱        ⋱
```
Let's see if tests pass with this.