### PR TITLE
Aggressive constprop in Dirichlet

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.5.13"
+version = "0.5.14"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Spaces/Chebyshev/ChebyshevOperators.jl
+++ b/src/Spaces/Chebyshev/ChebyshevOperators.jl
@@ -125,11 +125,19 @@ function getindex(op::ConcreteEvaluation{Chebyshev{DD,RR},M,OT,T},
     end
 end
 
-function Dirichlet(S::Chebyshev,order)
+@inline function _Dirichlet_Chebyshev(S, order)
     order == 0 && return ConcreteDirichlet(S,ArraySpace([ConstantSpace.(Point.(endpoints(domain(S))))...]),0)
     default_Dirichlet(S,order)
 end
-
+@static if VERSION >= v"1.8"
+    Base.@constprop :aggressive function Dirichlet(S::Chebyshev, order)
+        _Dirichlet_Chebyshev(S, order)
+    end
+else
+    function Dirichlet(S::Chebyshev, order)
+        _Dirichlet_Chebyshev(S, order)
+    end
+end
 
 function getindex(op::ConcreteDirichlet{<:Chebyshev},
                                              k::Integer,j::Integer)

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -304,4 +304,19 @@ using ApproxFunOrthogonalPolynomials: forwardrecurrence
         nmin = min(length(a), length(b))
         @test a[1:nmin] ≈ b[1:nmin]
     end
+
+    @testset "constant propagation in Dirichlet" begin
+        D = if VERSION >= v"1.8"
+            @inferred (r -> Dirichlet(r))(Chebyshev(0..1))
+        else
+            Dirichlet(Chebyshev(0..1))
+        end
+        # Dirichlet constraints don't depend on the domain
+        D2 = Dirichlet(Chebyshev())
+        @test Matrix(D[:, 1:4]) == Matrix(D2[:, 1:4])
+
+        D = @inferred (() -> Dirichlet(Chebyshev(), 2))()
+        D2 = @inferred (() -> Dirichlet(Chebyshev(-1..1), 2))()
+        @test Matrix(D[:, 1:4]) == Matrix(D2[:, 1:4])
+    end
 end


### PR DESCRIPTION
After this, the following is type-inferred:
```julia
julia> @inferred (r -> Dirichlet(r))(Chebyshev(0..1))
ConcreteDirichlet : Chebyshev(0..1) → 2-element ArraySpace:
ConstantSpace{DomainSets.Point{Int64}, Float64}[ConstantSpace(Point(0)), ConstantSpace(Point(1))]
 1.0  -1.0  1.0  -1.0  1.0  -1.0  1.0  -1.0  1.0  -1.0  ⋯
 1.0   1.0  1.0   1.0  1.0   1.0  1.0   1.0  1.0   1.0  ⋯
```