### PR TITLE
Split test macro to separate file

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,27 +11,7 @@ end
     @test reverseorientation(Arc(1,2,(0.1,0.2))) == Arc(1,2,(0.2,0.1))
 end
 
-function test_transform!(v, v2, S)
-    v .= rand.(eltype(v))
-    v2 .= v
-    @test itransform(S, transform(S, v)) ≈ v
-    @test transform(S, itransform(S, v)) ≈ v
-    transform!(S, v)
-    @test transform(S, v2) ≈ v
-    itransform!(S, v)
-    @test v2 ≈ v
-end
-
-macro verbose(ex)
-    head = ex.head
-    args = ex.args
-    @assert args[1] == Symbol("@testset")
-    name = args[3] isa String ? args[3] : nothing
-    if VERSION >= v"1.8"
-        insert!(args, 3, Expr(:(=), :verbose, true))
-    end
-    Expr(head, args...)
-end
+include("testutils.jl")
 
 include("ClenshawTest.jl")
 include("ChebyshevTest.jl")

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -1,0 +1,26 @@
+using ApproxFunOrthogonalPolynomials
+using LinearAlgebra
+using Test
+
+function test_transform!(v, v2, S)
+    v .= rand.(eltype(v))
+    v2 .= v
+    @test itransform(S, transform(S, v)) ≈ v
+    @test transform(S, itransform(S, v)) ≈ v
+    transform!(S, v)
+    @test transform(S, v2) ≈ v
+    itransform!(S, v)
+    @test v2 ≈ v
+end
+
+macro verbose(ex)
+    head = ex.head
+    args = ex.args
+    @assert args[1] == Symbol("@testset")
+    name = args[3] isa String ? args[3] : nothing
+    if VERSION >= v"1.8"
+        insert!(args, 3, Expr(:(=), :verbose, true))
+    end
+    Expr(head, args...)
+end
+


### PR DESCRIPTION
This makes tests simpler, as we may include `test/testutils.jl` before including a test file.