### PR TITLE
Constant propagation in `Multiplication(f, ::Ultraspherical)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.5.16"
+version = "0.5.17"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ApproxFunBase = "0.7.34"
+ApproxFunBase = "0.7.37"
 ApproxFunBaseTest = "0.1"
 Aqua = "0.5"
 BandedMatrices = "0.16, 0.17"

--- a/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
+++ b/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
@@ -26,21 +26,24 @@ Base.stride(M::ConcreteMultiplication{U,V}) where {U<:Ultraspherical,V<:Chebyshe
 Base.stride(M::ConcreteMultiplication{U,V}) where {U<:Ultraspherical,V<:Ultraspherical} =
     stride(M.f)
 
-
-function Multiplication(f::Fun{C},sp::Ultraspherical{Int}) where C<:Chebyshev
+@inline function _Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical{Int})
     if order(sp) == 1
         cfs = f.coefficients
         MultiplicationWrapper(f,
             SpaceOperator(
-                length(cfs) > 0 ?
-                    SymToeplitzOperator(cfs/2) +
-                        HankelOperator(view(cfs,3:length(cfs))/(-2)) :
+                SymToeplitzOperator(cfs/2) +
                     HankelOperator(view(cfs,3:length(cfs))/(-2)),
-                          sp,sp))
-
+                sp, sp)
+        )
     else
         ConcreteMultiplication(f,sp)
     end
+end
+@static if VERSION >= v"1.8"
+    Base.@constprop aggressive Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical{Int}) =
+        _Multiplication(f, sp)
+else
+    Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical{Int}) = _Multiplication(f, sp)
 end
 
 

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -305,19 +305,41 @@ using ApproxFunOrthogonalPolynomials: forwardrecurrence
         @test a[1:nmin] ≈ b[1:nmin]
     end
 
-    @testset "constant propagation in Dirichlet" begin
-        D = if VERSION >= v"1.8"
-            @inferred (r -> Dirichlet(r))(Chebyshev(0..1))
-        else
-            Dirichlet(Chebyshev(0..1))
-        end
-        # Dirichlet constraints don't depend on the domain
-        D2 = Dirichlet(Chebyshev())
-        @test Matrix(D[:, 1:4]) == Matrix(D2[:, 1:4])
+    @testset "Constant propagation" begin
+        @testset "Dirichlet" begin
+            D = if VERSION >= v"1.8"
+                @inferred (r -> Dirichlet(r))(Chebyshev(0..1))
+            else
+                Dirichlet(Chebyshev(0..1))
+            end
+            # Dirichlet constraints don't depend on the domain
+            D2 = Dirichlet(Chebyshev())
+            @test Matrix(D[:, 1:4]) == Matrix(D2[:, 1:4])
 
-        D = @inferred (() -> Dirichlet(Chebyshev(), 2))()
-        D2 = @inferred (() -> Dirichlet(Chebyshev(-1..1), 2))()
-        @test Matrix(D[:, 1:4]) == Matrix(D2[:, 1:4])
+            D = @inferred (() -> Dirichlet(Chebyshev(), 2))()
+            D2 = @inferred (() -> Dirichlet(Chebyshev(-1..1), 2))()
+            @test Matrix(D[:, 1:4]) == Matrix(D2[:, 1:4])
+        end
+
+        @testset "Multiplication" begin
+            f = () -> Fun(0..1) * Derivative(Chebyshev(0..1))
+            A = VERSION >= v"1.8" ? (@inferred f()) : f()
+            @test (A * Fun(0..1))(0.5) ≈ 0.5
+
+            f = () -> Fun() * Derivative(Chebyshev())
+            A = VERSION >= v"1.8" ? (@inferred f()) : f()
+            @test (A * Fun())(0.5) ≈ 0.5
+        end
+    end
+
+    @testset "Inference in PlusOperator" begin
+        f = () -> Derivative(Chebyshev(0..1)) + Derivative(Chebyshev(0..1))
+        A = VERSION >= v"1.8" ? (@inferred f()) : f()
+        @test (A * Fun(0..1))(0.5) ≈ 2.0
+
+        f = () -> Derivative(Chebyshev()) + Derivative(Chebyshev())
+        A = VERSION >= v"1.8" ? (@inferred f()) : f()
+        @test (A * Fun())(0.5) ≈ 2.0
     end
 
     @testset "Evaluation" begin

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -35,11 +35,11 @@ using ApproxFunOrthogonalPolynomials: jacobip
     end
 
     @testset "Normalized space" begin
-        for f in Any[x -> 3x^3 + 5x^2 + 2, x->x, identity]
-            for dt in Any[(), (0..1,)],
-                    S in Any[Ultraspherical(1, dt...),
+        for f in (x -> 3x^3 + 5x^2 + 2, x->x, identity)
+            for dt in ((), (0..1,)),
+                    S in (Ultraspherical(1, dt...),
                              Ultraspherical(0.5,dt...),
-                             Ultraspherical(3, dt...)]
+                             Ultraspherical(3, dt...))
 
                 NS = NormalizedPolynomialSpace(S)
                 fS = Fun(f, S)
@@ -63,16 +63,16 @@ using ApproxFunOrthogonalPolynomials: jacobip
             L = ultra2leg(ApproxFunBase.canonicalspace(U))
             NormalizedPolynomialSpace(L)
         end
-        @testset for T in Any[Float32, Float64], ET in Any[T, complex(T)]
+        @testset for T in (Float32, Float64), ET in (T, complex(T))
             v = Array{ET}(undef, 10)
             v2 = similar(v)
             M = Array{ET}(undef, 10, 10)
             M2 = similar(M)
             A = Array{ET}(undef, 10, 10, 10)
             A2 = similar(A)
-            @testset for d in Any[(), (0..1,)], order in Any[0.5, 1, 3]
+            @testset for d in ((), (0..1,)), order in (0.5, 1, 3)
                 U = Ultraspherical(order, d...)
-                Slist = Any[U, NormalizedPolynomialSpace(U)]
+                Slist = (U, NormalizedPolynomialSpace(U))
                 @testset for S in Slist
                     if order == 0.5
                         L = ultra2leg(S)
@@ -100,6 +100,7 @@ using ApproxFunOrthogonalPolynomials: jacobip
                     test_transform!(A, A2, S)
                 end
             end
+        endend
         end
     end
 
@@ -110,13 +111,13 @@ using ApproxFunOrthogonalPolynomials: jacobip
 
     @testset "Evaluation" begin
         c = [i^2 for i in 1:4]
-        @testset for d in Any[0..1, ChebyshevInterval()], order in Any[1, 2, 0.5]
-            @testset for _sp in Any[Ultraspherical(order), Ultraspherical(order,d)],
-                    sp in Any[_sp, NormalizedPolynomialSpace(_sp)]
+        @testset for d in (0..1, ChebyshevInterval()), order in (1, 2, 0.5)
+            @testset for _sp in (Ultraspherical(order), Ultraspherical(order,d)),
+                    sp in (_sp, NormalizedPolynomialSpace(_sp))
                 d = domain(sp)
                 f = Fun(sp, c)
-                for ep in [leftendpoint, rightendpoint],
-                        ev in [ApproxFunBase.ConcreteEvaluation, Evaluation]
+                for ep in (leftendpoint, rightendpoint),
+                        ev in (ApproxFunBase.ConcreteEvaluation, Evaluation)
                     E = @inferred ev(sp, ep, 0)
                     @test E[2:4] ≈ E[1:4][2:end]
                     @test E[1:2:5] ≈ E[1:5][1:2:5]

--- a/test/miscAFBase.jl
+++ b/test/miscAFBase.jl
@@ -143,25 +143,6 @@ Base.:(==)(a::UniqueInterval, b::UniqueInterval) = (@assert a.parentinterval == 
         end
     end
 
-    @testset "inplace transform" begin
-        @testset for sp_c in Any[Legendre(), Chebyshev(), Jacobi(1,2), Jacobi(0.3, 2.3),
-                Ultraspherical(1), Ultraspherical(2)]
-            @testset for sp in Any[sp_c, NormalizedPolynomialSpace(sp_c)]
-                v = rand(10)
-                v2 = copy(v)
-                @test itransform!(sp, transform!(sp, v)) ≈ v
-                @test transform!(sp, v) ≈ transform(sp, v2)
-                @test itransform(sp, v) ≈ v2
-                @test itransform!(sp, v) ≈ v2
-
-                # different vector
-                p_fwd = ApproxFunBase.plan_transform!(sp, v)
-                p_inv = ApproxFunBase.plan_itransform!(sp, v)
-                @test p_inv * copy(p_fwd * copy(v)) ≈ v
-            end
-        end
-    end
-
     @testset "conversion" begin
         C12 = Conversion(Chebyshev(), NormalizedLegendre())
         C21 = Conversion(NormalizedLegendre(), Chebyshev())
@@ -370,6 +351,13 @@ Base.:(==)(a::UniqueInterval, b::UniqueInterval) = (@assert a.parentinterval == 
         @test (@inferred((L -> L^4)(L)))(x,y) ≈ (L*L*L*L)(x,y)
         @test (L * one(L))(x,y) ≈ L(x,y)
         @test (L + zero(L))(x,y) ≈ L(x,y)
+    end
+
+    @testset "Multiplication" begin
+        # empty coefficients
+        f = () -> Multiplication(Fun(Chebyshev(), Float64[]), Ultraspherical(1))
+        M = VERSION >= v"1.8" ? (@inferred f()) : f()
+        @test all(iszero, coefficients(M * Fun()))
     end
 end
 

--- a/test/miscAFBase.jl
+++ b/test/miscAFBase.jl
@@ -143,6 +143,25 @@ Base.:(==)(a::UniqueInterval, b::UniqueInterval) = (@assert a.parentinterval == 
         end
     end
 
+    @testset "inplace transform" begin
+        @testset for sp_c in (Legendre(), Chebyshev(), Jacobi(1,2), Jacobi(0.3, 2.3),
+                Ultraspherical(1), Ultraspherical(2))
+            @testset for sp in (sp_c, NormalizedPolynomialSpace(sp_c))
+                v = rand(10)
+                v2 = copy(v)
+                @test itransform!(sp, transform!(sp, v)) ≈ v
+                @test transform!(sp, v) ≈ transform(sp, v2)
+                @test itransform(sp, v) ≈ v2
+                @test itransform!(sp, v) ≈ v2
+
+                # different vector
+                p_fwd = ApproxFunBase.plan_transform!(sp, v)
+                p_inv = ApproxFunBase.plan_itransform!(sp, v)
+                @test p_inv * copy(p_fwd * copy(v)) ≈ v
+            end
+        end
+    end
+
     @testset "conversion" begin
         C12 = Conversion(Chebyshev(), NormalizedLegendre())
         C21 = Conversion(NormalizedLegendre(), Chebyshev())


### PR DESCRIPTION
After this, the following is fully type-inferred:
```julia
julia> @inferred (() -> Fun() * Derivative(Chebyshev()))()
TimesOperator : Chebyshev() → Ultraspherical(1)
 0.0  0.0  1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅   0.5  0.0  1.5   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅   1.0  0.0  2.0   ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅   1.5  0.0  2.5   ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅   2.0  0.0  3.0   ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅   2.5  0.0  3.5   ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   3.0  0.0  4.0   ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   3.5  0.0  4.5  ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   4.0  0.0  ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   4.5  ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
```