### PR TITLE
Accept `Number` orders in calculus operators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.5.17"
+version = "0.5.18"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/src/Spaces/Chebyshev/ChebyshevOperators.jl
+++ b/src/Spaces/Chebyshev/ChebyshevOperators.jl
@@ -214,8 +214,10 @@ end
 
 ## Derivative
 
-Derivative(sp::Chebyshev{DD},order::Integer) where {DD<:IntervalOrSegment} =
+function Derivative(sp::Chebyshev{DD},order::Number) where {DD<:IntervalOrSegment}
+    @assert Integer(order) == order "order must be an integer"
     ConcreteDerivative(sp,order)
+end
 
 
 rangespace(D::ConcreteDerivative{Chebyshev{DD,RR}}) where {DD<:IntervalOrSegment,RR} =

--- a/src/Spaces/Hermite/Hermite.jl
+++ b/src/Spaces/Hermite/Hermite.jl
@@ -87,8 +87,9 @@ Fun(::typeof(identity), sp::GaussWeight) = Fun(identity, sp.space)
 
 spacescompatible(a::GaussWeight,b::GaussWeight)=spacescompatible(a.space,b.space)&&isapprox(a.L,b.L)
 
-function Derivative(sp::GaussWeight,k::Integer)
-   if k == 1
+function Derivative(sp::GaussWeight,k::Number)
+    @assert Integer(k) == k "order must be an integer"
+    if k == 1
         x = Multiplication(Fun(identity,sp.space),sp.space)
         D = Derivative(sp.space)
         D2 = D - (2sp.L)x

--- a/src/Spaces/Jacobi/JacobiOperators.jl
+++ b/src/Spaces/Jacobi/JacobiOperators.jl
@@ -1,6 +1,7 @@
 ## Derivative
 
-function Derivative(J::Jacobi,k::Integer)
+function Derivative(J::Jacobi,k::Number)
+    @assert Integer(k) == k "order must be an integer"
     k==1 ? ConcreteDerivative(J,1) :
         DerivativeWrapper(
             TimesOperator(
@@ -33,7 +34,8 @@ Evaluation(S::NormalizedPolynomialSpace{<:Jacobi},x::Number,o::Integer) = Concre
 
 ## Integral
 
-function Integral(J::Jacobi,k::Integer)
+function Integral(J::Jacobi,k::Number)
+    @assert Integer(k) == k "order must be an integer"
     if k > 1
         Q=Integral(J,1)
         IntegralWrapper(TimesOperator(Integral(rangespace(Q),k-1),Q),J,k)

--- a/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
+++ b/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
@@ -54,9 +54,12 @@ end
 #Derivative(d::IntervalOrSegment)=Derivative(1,d)
 
 
-Derivative(sp::Ultraspherical{LT,DD},m::Integer) where {LT,DD<:IntervalOrSegment} =
+function Derivative(sp::Ultraspherical{LT,DD}, m::Number) where {LT,DD<:IntervalOrSegment}
+    @assert Integer(m) == m "order must be an integer"
     ConcreteDerivative(sp,m)
-function Integral(sp::Ultraspherical{LT,DD},m::Integer) where {LT,DD<:IntervalOrSegment}
+end
+function Integral(sp::Ultraspherical{LT,DD}, m::Number) where {LT,DD<:IntervalOrSegment}
+    @assert Integer(m) == m "order must be an integer"
     λ = order(sp)
     if m ≤ λ
         ConcreteIntegral(sp,m)


### PR DESCRIPTION
This would help with constant propagation in certain cases, using static integers as orders. Currently, `StaticInt`s are not `Integer`s, although https://github.com/SciML/Static.jl/pull/92 would mean that this change in unnecessary, in which case this may be reverted.
```julia
julia> @code_typed rangespace(Derivative(Chebyshev(), 1))
CodeInfo(
1 ─ %1 = Base.getfield(D, :order)::Int64
│   %2 = (%1 === 0)::Bool
│   %3 = Base.not_int(%2)::Bool
└──      goto #3 if not %3
2 ─ %5 = %new(Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}, %1, $(QuoteNode(-1.0..1.0 (Chebyshev))))::Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}
└──      goto #4
3 ─ %7 = %new(Core.AssertionError, "m ≠ 0")::AssertionError
│        Base.throw(%7)::Union{}
└──      unreachable
4 ─      goto #5
5 ─      return %5
) => Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}

julia> using Static

julia> @code_typed rangespace(Derivative(Chebyshev(), StaticInt(1)))
CodeInfo(
1 ─     return $(QuoteNode(Ultraspherical(static(1))))
) => Ultraspherical{StaticInt{1}, ChebyshevInterval{Float64}, Float64}
```
Another example:
```julia
julia> @code_typed ApproxFunBase.promoterangespace(Derivative(Chebyshev(), 1), Ultraspherical(1, ChebyshevInterval()))
CodeInfo(
1 ─ %1  = Base.getfield(P, :order)::Int64
│   %2  = (%1 === 0)::Bool
│   %3  = Base.not_int(%2)::Bool
└──       goto #3 if not %3
2 ─ %5  = %new(Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}, %1, $(QuoteNode(-1.0..1.0 (Chebyshev))))::Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}
└──       goto #4
3 ─ %7  = %new(Core.AssertionError, "m ≠ 0")::AssertionError
│         Base.throw(%7)::Union{}
└──       unreachable
4 ─       goto #5
5 ─       goto #6
6 ─ %12 = invoke ApproxFunBase.promoterangespace(P::ApproxFunBase.ConcreteDerivative{Chebyshev{ChebyshevInterval{Float64}, Float64}, Int64, Float64}, sp::Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}, %5::Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64})::Union{ApproxFunBase.ConcreteDerivative{Chebyshev{ChebyshevInterval{Float64}, Float64}, Int64, Float64}, TimesOperator{Float64, _A, _B, Operator{Float64}} where {_A, _B}}
└──       return %12
) => Union{ApproxFunBase.ConcreteDerivative{Chebyshev{ChebyshevInterval{Float64}, Float64}, Int64, Float64}, TimesOperator{Float64, _A, _B, Operator{Float64}} where {_A, _B}}

julia> @code_typed ApproxFunBase.promoterangespace(Derivative(Chebyshev(), StaticInt(1)), Ultraspherical(StaticInt(1), ChebyshevInterval()))
CodeInfo(
1 ─     return $(QuoteNode(ConcreteDerivative : Chebyshev() → Ultraspherical(static(1))))
) => ApproxFunBase.ConcreteDerivative{Chebyshev{ChebyshevInterval{Float64}, Float64}, StaticInt{1}, Float64}
```