### PR TITLE
Add type parameter to Jacobi

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.5.19"
+version = "0.6.0"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
+++ b/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
@@ -26,7 +26,7 @@ Base.stride(M::ConcreteMultiplication{U,V}) where {U<:Ultraspherical,V<:Chebyshe
 Base.stride(M::ConcreteMultiplication{U,V}) where {U<:Ultraspherical,V<:Ultraspherical} =
     stride(M.f)
 
-@inline function _Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical)
+@inline function _Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical{Int})
     if order(sp) == 1
         cfs = f.coefficients
         MultiplicationWrapper(f,
@@ -40,10 +40,10 @@ Base.stride(M::ConcreteMultiplication{U,V}) where {U<:Ultraspherical,V<:Ultrasph
     end
 end
 @static if VERSION >= v"1.8"
-    Base.@constprop aggressive Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical) =
+    Base.@constprop aggressive Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical{Int}) =
         _Multiplication(f, sp)
 else
-    Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical) = _Multiplication(f, sp)
+    Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical{Int}) = _Multiplication(f, sp)
 end
 
 

--- a/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
+++ b/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
@@ -26,7 +26,7 @@ Base.stride(M::ConcreteMultiplication{U,V}) where {U<:Ultraspherical,V<:Chebyshe
 Base.stride(M::ConcreteMultiplication{U,V}) where {U<:Ultraspherical,V<:Ultraspherical} =
     stride(M.f)
 
-@inline function _Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical{Int})
+@inline function _Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical)
     if order(sp) == 1
         cfs = f.coefficients
         MultiplicationWrapper(f,
@@ -40,10 +40,10 @@ Base.stride(M::ConcreteMultiplication{U,V}) where {U<:Ultraspherical,V<:Ultrasph
     end
 end
 @static if VERSION >= v"1.8"
-    Base.@constprop aggressive Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical{Int}) =
+    Base.@constprop aggressive Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical) =
         _Multiplication(f, sp)
 else
-    Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical{Int}) = _Multiplication(f, sp)
+    Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical) = _Multiplication(f, sp)
 end
 
 
@@ -134,8 +134,12 @@ function Conversion(A::Chebyshev,B::Ultraspherical)
     end
 end
 
+
+isequalhalf(x) = x == 0.5
+isequalhalf(::Integer) = false
+
 function Conversion(A::Ultraspherical,B::Chebyshev)
-    if order(A) == 1//2
+    if isequalhalf(order(A))
         ConcreteConversion(A,B)
     else
         error("Not implemented")

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -462,4 +462,15 @@ using StaticArrays: SVector
             end
         end
     end
+
+    @testset "type inference" begin
+        x = @inferred ApproxFunBase.maxspace(Jacobi(1,1), Jacobi(2,2))
+        @test x == Jacobi(2,2)
+
+        x = @inferred ApproxFunBase.union_rule(Chebyshev(), Jacobi(1,1))
+        @test x == Jacobi(-0.5, -0.5)
+
+        x = @inferred ApproxFunBase.conversion_rule(Jacobi(1,1), Jacobi(2,2))
+        @test x == Jacobi(1,1)
+    end
 end

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -153,4 +153,11 @@ using ApproxFunOrthogonalPolynomials: jacobip
             end
         end
     end
+
+    @testset "Multiplication" begin
+        M = Multiplication(Fun(), Ultraspherical(0.5))
+        f = Fun(Ultraspherical(0.5))
+        f2 = Fun(x->x^2, Ultraspherical(0.5))
+        @test M * f ≈ f2
+    end
 end

--- a/test/showtest.jl
+++ b/test/showtest.jl
@@ -4,13 +4,15 @@ using ApproxFunBase
 	@test repr(NormalizedChebyshev()) == "NormalizedChebyshev()"
 	@test repr(Ultraspherical(1)) == "Ultraspherical(1)"
 	@test repr(Legendre()) == "Legendre()"
-	@test repr(Jacobi(1,2)) == "Jacobi(1.0,2.0)"
+	@test repr(Jacobi(1,2)) == "Jacobi(1,2)"
+	@test repr(Jacobi(1.0,2.0)) == "Jacobi(1.0,2.0)"
 
 	@test repr(Chebyshev(0..1)) == "Chebyshev(0..1)"
 	@test repr(NormalizedChebyshev(0..1)) == "NormalizedChebyshev(0..1)"
 	@test repr(Ultraspherical(1,0..1)) == "Ultraspherical(1,0..1)"
 	@test repr(Legendre(0..1)) == "Legendre(0..1)"
-	@test repr(Jacobi(1,2,0..1)) == "Jacobi(1.0,2.0,0..1)"
+	@test repr(Jacobi(1,2,0..1)) == "Jacobi(1,2,0..1)"
+	@test repr(Jacobi(1.0,2.0,0..1)) == "Jacobi(1.0,2.0,0..1)"
 
 	io = IOBuffer()
 	@testset "Derivative" begin


### PR DESCRIPTION
Using integer orders makes comparisons with integers easier, e.g. `n + 0.5` is statically known to not be an integer if `n` is an integer.

On master
```julia
julia> @inferred ApproxFunBase.maxspace(Jacobi(1,1), Jacobi(2,2))
ERROR: return type Jacobi{ChebyshevInterval{Float64}, Float64} does not match inferred return type Any
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] top-level scope
   @ REPL[5]:1
```
After this PR, this is fully type-inferred.
```julia
julia> @inferred ApproxFunBase.maxspace(Jacobi(1,1), Jacobi(2,2))
Jacobi(2,2)
```