### PR TITLE
revert moving integral over domain

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.5.20"
+version = "0.5.21"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/src/Spaces/IntervalSpace.jl
+++ b/src/Spaces/IntervalSpace.jl
@@ -1,5 +1,11 @@
 Space(d::IntervalOrSegment) = Chebyshev(d)
 Space(d::FullSpace{<:Real}) = Chebyshev(Line())
 
+# TODO: mode these functions to ApproxFunBase
+# Currently, Space(d::Interval) isn't type-stable, so the spaces are
+# explicitly listed in these calls.
 Fun(::typeof(identity), d::IntervalOrSegment{<:Number}) =
     Fun(Chebyshev(d), [mean(d), complexlength(d)/2])
+
+# the default domain space is higher to avoid negative ultraspherical spaces
+Integral(d::IntervalOrSegment,n::Integer) = Integral(Ultraspherical(1,d), n)

--- a/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
+++ b/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
@@ -248,6 +248,7 @@ end
 
 
 function coefficients(g::AbstractVector,sp::Ultraspherical{Int},C::Chebyshev)
+    domainscompatible(C,sp) || throw(ArgumentError("domains don't match: $(domain(sp)) and $(domain(C))"))
     if order(sp) == 1
         ultraiconversion(g)
     else
@@ -256,6 +257,7 @@ function coefficients(g::AbstractVector,sp::Ultraspherical{Int},C::Chebyshev)
     end
 end
 function coefficients(g::AbstractVector,C::Chebyshev,sp::Ultraspherical)
+    domainscompatible(C,sp) || throw(ArgumentError("domains don't match: $(domain(C)) and $(domain(sp))"))
     if order(sp) == 1
         ultraconversion(g)
     else

--- a/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
+++ b/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
@@ -58,14 +58,14 @@ function Derivative(sp::Ultraspherical{LT,DD}, m::Number) where {LT,DD<:Interval
     assert_integer(m)
     ConcreteDerivative(sp,m)
 end
-function Integral(sp::Ultraspherical{LT,DD}, m::Number) where {LT,DD<:IntervalOrSegment}
+function Integral(sp::Ultraspherical{<:Any,<:IntervalOrSegment}, m::Number)
     assert_integer(m)
     λ = order(sp)
     if m ≤ λ
         ConcreteIntegral(sp,m)
     else # Convert up
-        nsp = Ultraspherical(λ+1,domain(sp))
-        IntegralWrapper(Integral(nsp,m)*Conversion(sp,nsp),m)
+        nsp = Ultraspherical(m,domain(sp))
+        IntegralWrapper(ConcreteIntegral(nsp,m)*Conversion(sp,nsp),m)
     end
 end
 

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -39,6 +39,18 @@ using ApproxFunOrthogonalPolynomials: forwardrecurrence
         @test y == 2Fun()
     end
 
+    @testset "inference in Space(::Interval)" begin
+        S = @inferred Space(0..1)
+        f = Fun(S)
+        g = Fun(domain(S))
+        @test f(0.2) ≈ g(0.2) ≈ 0.2
+
+        S = Space(0.0..1.0)
+        f = Fun(S)
+        g = Fun(domain(S))
+        @test f(0.2) ≈ g(0.2) ≈ 0.2
+    end
+
     @testset "Algebra" begin
         ef = @inferred Fun(exp,ChebyshevInterval())
         @test ef == @inferred -(-ef)

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -165,4 +165,15 @@ using ApproxFunOrthogonalPolynomials: jacobip
             end
         end
     end
+
+    @testset "Integral" begin
+        d = 0..1
+        A = @inferred Integral(0..1)
+        x = Derivative() * A * Fun(d)
+        @test x(0.2) ≈ 0.2
+        d = 0.0..1.0
+        A = @inferred Integral(d)
+        x = Derivative() * A * Fun(d)
+        @test x(0.2) ≈ 0.2
+    end
 end


### PR DESCRIPTION
This harms type-inferrence, as `Space(d::Interval)` isn't concretely inferred.