### PR TITLE
hasconversion for tensorspace

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.6.5"
+version = "0.6.6"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -412,14 +412,8 @@ function Fun(::typeof(identity), S::NormalizedPolynomialSpace)
     Fun(S, coeffs)
 end
 
-function _conversion_maxspace_rule(a::NormalizedPolynomialSpace{S}, b::S) where S<:PolynomialSpace
-    domainscompatible(domain(a), domain(b)) ? b : NoSpace()
-end
 function conversion_rule(a::NormalizedPolynomialSpace{S}, b::S) where S<:PolynomialSpace
-    _conversion_maxspace_rule(a, b)
-end
-function maxspace_rule(a::NormalizedPolynomialSpace{S}, b::S) where S<:PolynomialSpace
-    _conversion_maxspace_rule(a, b)
+    domainscompatible(domain(a), domain(b)) ? a : NoSpace()
 end
 
 bandwidths(C::ConcreteConversion{NormalizedPolynomialSpace{S,D,R},S}) where {S,D,R} = (0, 0)

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -545,4 +545,14 @@ using Static
         x = @inferred ApproxFunBase.conversion_rule(Jacobi(1,1), Jacobi(2,2))
         @test x == Jacobi(1,1)
     end
+
+    @testset "Tensor space conversions" begin
+        @test ApproxFunBase.hasconversion(Chebyshev()*Legendre(), Chebyshev()*Legendre())
+        @test ApproxFunBase.hasconversion(Chebyshev()*Legendre(), Chebyshev()*NormalizedLegendre())
+        @test ApproxFunBase.hasconversion(Chebyshev()*Legendre(), NormalizedChebyshev()*Legendre())
+        @test ApproxFunBase.hasconversion(Chebyshev()*NormalizedLegendre(), Chebyshev()*Legendre())
+        @test ApproxFunBase.hasconversion(NormalizedChebyshev()*Legendre(), Chebyshev()*Legendre())
+        @test ApproxFunBase.hasconversion(NormalizedChebyshev()*NormalizedLegendre(), Chebyshev()*Legendre())
+        @test ApproxFunBase.hasconversion(Chebyshev()*Legendre(), NormalizedChebyshev()*NormalizedLegendre())
+    end
 end


### PR DESCRIPTION
After this, the following works:
```julia
julia> ApproxFunBase.hasconversion(Chebyshev()*Legendre(), Chebyshev()*NormalizedLegendre())
true
```
On master
```julia
julia> f = Fun((x,y)->x^10*y^4 + x^2*y^3, Chebyshev()*Legendre());
```
TTFX
```julia
julia> @time Fun(f, Chebyshev()*NormalizedLegendre());
 12.396606 seconds (41.16 M allocations: 2.226 GiB, 6.72% gc time, 99.99% compilation time)
```
Benchmark
```julia
julia> @btime Fun($f, Chebyshev()*NormalizedLegendre());
  287.812 μs (416 allocations: 66.70 KiB)
```
This PR
TTFX
```julia
julia> @time Fun(f, Chebyshev()*NormalizedLegendre());
 10.915021 seconds (38.30 M allocations: 2.089 GiB, 6.96% gc time, 99.99% compilation time)
```
Benchmark
```julia
julia> @btime Fun($f, Chebyshev()*NormalizedLegendre());
  66.401 μs (1386 allocations: 113.58 KiB)
```
The allocations go up, but the execution time is lower. 