### PR TITLE
Ignore ApproxFunBaseTest as a dep

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,8 @@ using Test
 using Aqua
 
 @testset "Project quality" begin
-    Aqua.test_all(ApproxFunOrthogonalPolynomials, ambiguities=false)
+    Aqua.test_all(ApproxFunOrthogonalPolynomials, ambiguities=false,
+        stale_deps=(; ignore=[:ApproxFunBaseTest]))
 end
 
 @testset "Domain" begin


### PR DESCRIPTION
This lets one carry out downstream tests in ApproxFunBaseTest by developing the package, without being flagged by Aqua.