### PR TITLE
Fix deprecated Vararg syntax

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.6.7"
+version = "0.6.8"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/src/Spaces/Ultraspherical/ContinuousSpace.jl
+++ b/src/Spaces/Ultraspherical/ContinuousSpace.jl
@@ -14,7 +14,7 @@ isperiodic(C::ContinuousSpace) = isperiodic(domain(C))
 
 spacescompatible(a::ContinuousSpace,b::ContinuousSpace) = domainscompatible(a,b)
 conversion_rule(a::ContinuousSpace,
-                b::PiecewiseSpace{<:Tuple{Vararg{<:ChebyshevDirichlet{1,1}}},<:Any,<:Real}) = a
+                b::PiecewiseSpace{<:Tuple{Vararg{ChebyshevDirichlet{1,1}}},<:Any,<:Real}) = a
 
 plan_transform(sp::ContinuousSpace,vals::AbstractVector) =
     TransformPlan{eltype(vals),typeof(sp),false,Nothing}(sp,nothing)
@@ -132,7 +132,7 @@ coefficients(cfsin::AbstractVector,A::ContinuousSpace,B::ContinuousSpace) =
 
 # We implemnt conversion between continuous space and PiecewiseSpace with Chebyshev dirichlet
 const PiecewiseSpaceReal{CD} = PiecewiseSpace{CD,<:Any,<:Real}
-const PiecewiseSpaceRealChebyDirichlet11 = PiecewiseSpaceReal{<:Tuple{Vararg{<:ChebyshevDirichlet{1,1}}}}
+const PiecewiseSpaceRealChebyDirichlet11 = PiecewiseSpaceReal{<:Tuple{Vararg{ChebyshevDirichlet{1,1}}}}
 
 function Conversion(ps::PiecewiseSpaceRealChebyDirichlet11, cs::ContinuousSpace)
     @assert ps == canonicalspace(cs)


### PR DESCRIPTION
This used to error with `julia --project --depwarn=error`