### PR TITLE
`supportsinplacetransform` for float-domain Chebyshev

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.6.8"
+version = "0.6.9"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
@@ -20,7 +20,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ApproxFunBase = "0.7.67"
+ApproxFunBase = "0.7.71"
 ApproxFunBaseTest = "0.1"
 Aqua = "0.5"
 BandedMatrices = "0.16, 0.17"

--- a/src/ApproxFunOrthogonalPolynomials.jl
+++ b/src/ApproxFunOrthogonalPolynomials.jl
@@ -42,7 +42,7 @@ import ApproxFunBase: Fun, SubSpace, WeightSpace, NoSpace, HeavisideSpace,
                     block, blockstart, blockstop, blocklengths, isblockbanded,
                     pointscompatible, affine_setdiff, complexroots,
                     ℓ⁰, recα, recβ, recγ, ℵ₀, ∞, RectDomain,
-                    assert_integer
+                    assert_integer, supportsinplacetransform
 
 import DomainSets: Domain, indomain, UnionDomain, FullSpace, Point,
             Interval, ChebyshevInterval, boundary, rightendpoint, leftendpoint,

--- a/src/Spaces/Chebyshev/Chebyshev.jl
+++ b/src/Spaces/Chebyshev/Chebyshev.jl
@@ -68,6 +68,7 @@ Base.last(f::Fun{<:Chebyshev}) = reduce(+,coefficients(f))
 
 spacescompatible(a::Chebyshev,b::Chebyshev) = domainscompatible(a,b)
 hasfasttransform(::Chebyshev) = true
+supportsinplacetransform(::Chebyshev{<:Domain{T},T}) where {T<:AbstractFloat} = true
 
 
 ## Transform

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -385,6 +385,8 @@ setdomain(NS::NormalizedPolynomialSpace, d::Domain) = NormalizedPolynomialSpace(
 
 NormalizedPolynomialSpace(space::PolynomialSpace{D,R}) where {D,R} = NormalizedPolynomialSpace{typeof(space),D,R}(space)
 
+supportsinplacetransform(N::NormalizedPolynomialSpace) = supportsinplacetransform(N.space)
+
 function Conversion(L::NormalizedPolynomialSpace{S}, M::S) where S<:PolynomialSpace
     if L.space == M
         ConcreteConversion(L, M)


### PR DESCRIPTION
On master
```julia
julia> @btime Fun(x -> x^20, Chebyshev());
  107.806 μs (218 allocations: 19.08 KiB)
```
This PR
```julia
julia> @btime Fun(x -> x^20, Chebyshev());
  33.232 μs (118 allocations: 8.50 KiB)
```
The improvement comes from allocating fewer arrays, and carrying out transforms in-place.