### PR TITLE
`ConcreteDerivative` vector in Jacobi Derivative

### DIFF
--- a/src/Spaces/Jacobi/JacobiOperators.jl
+++ b/src/Spaces/Jacobi/JacobiOperators.jl
@@ -4,11 +4,13 @@
 Derivative(J::Jacobi) = ConcreteDerivative(J,1)
 @inline function _Derivative(J::Jacobi, k::Number)
     assert_integer(k)
-    k==1 ? ConcreteDerivative(J,1) :
-        DerivativeWrapper(
-            TimesOperator(
-                Derivative(Jacobi(J.b+1,J.a+1,J.domain),k-1),ConcreteDerivative(J,1)),
-        J, k)
+    if k==1
+        return ConcreteDerivative(J,1)
+    else
+        d = domain(J)
+        v = [ConcreteDerivative(Jacobi(J.b+i-1, J.a+i-1, d)) for i in k:-1:1]
+        DerivativeWrapper(TimesOperator(v), J, k)
+    end
 end
 @static if VERSION >= v"1.8"
     Base.@constprop :aggressive Derivative(J::Jacobi, k::Number) =

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -251,6 +251,9 @@ using Static
             @test Derivative(S)^3 * f ≈ Fun(x->6, S)
             @test Derivative(S)^4 * f ≈ zeros(S)
         end
+
+        @test (@inferred ((n) -> domainspace(Derivative(Jacobi(n,n), 2)))(1)) == Jacobi(1,1)
+        @test (@inferred ((n) -> rangespace(Derivative(Jacobi(n,n), 2)))(1)) == Jacobi(3,3)
     end
 
     @testset "identity Fun for interval domains" begin

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -252,8 +252,8 @@ using Static
             @test Derivative(S)^4 * f ≈ zeros(S)
         end
 
-        @test (@inferred ((n) -> domainspace(Derivative(Jacobi(n,n), 2)))(1)) == Jacobi(1,1)
-        @test (@inferred ((n) -> rangespace(Derivative(Jacobi(n,n), 2)))(1)) == Jacobi(3,3)
+        @test (@inferred (n -> domainspace(Derivative(Jacobi(n,n), 2)))(1)) == Jacobi(1,1)
+        @test (@inferred (n -> rangespace(Derivative(Jacobi(n,n), 2)))(1)) == Jacobi(3,3)
     end
 
     @testset "identity Fun for interval domains" begin


### PR DESCRIPTION
Explicitly unrolling the recursion helps with type inference. After this
```julia
julia> @inferred (n -> rangespace(Derivative(Jacobi(n,n), 2)))(1)
Jacobi(3,3)

julia> @inferred (n -> domainspace(Derivative(Jacobi(n,n), 2)))(1)
Jacobi(1,1)
```