### PR TITLE
Inference in normalized space multiplication

### DIFF
--- a/src/Spaces/Jacobi/JacobiOperators.jl
+++ b/src/Spaces/Jacobi/JacobiOperators.jl
@@ -178,7 +178,7 @@ function Conversion(L::Jacobi,M::Jacobi)
         end
     end
 
-    throw(ArgumentError("please implement $A → $B"))
+    throw(ArgumentError("please implement $L → $M"))
 end
 
 bandwidths(::ConcreteConversion{<:Jacobi,<:Jacobi}) = (0,1)

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -486,17 +486,16 @@ end
 
 function Multiplication(f::Fun{<:PolynomialSpace}, sp::NormalizedPolynomialSpace)
     unnorm_sp = canonicalspace(sp)
-    O = Conversion(unnorm_sp,sp) *
-            Multiplication(f,unnorm_sp) * Conversion(sp, unnorm_sp)
+    O = ConcreteConversion(unnorm_sp,sp) *
+            Multiplication(f,unnorm_sp) * ConcreteConversion(sp, unnorm_sp)
     MultiplicationWrapper(f, O, sp)
 end
 
-function Multiplication(f::Fun{ <: NormalizedPolynomialSpace}, sp::PolynomialSpace)
-    Multiplication(Conversion(space(f), canonicalspace(f))*f, sp)
+function Multiplication(f::Fun{<:NormalizedPolynomialSpace}, sp::PolynomialSpace)
+    Multiplication(ConcreteConversion(space(f), canonicalspace(f))*f, sp)
 end
 
-function Multiplication(f::Fun{U},sp::NormalizedPolynomialSpace) where U <: NormalizedPolynomialSpace
-    csp = canonicalspace(f)
-    fc = Conversion(space(f), csp)*f
+function Multiplication(f::Fun{<:NormalizedPolynomialSpace}, sp::NormalizedPolynomialSpace)
+    fc = ConcreteConversion(space(f), canonicalspace(f))*f
     Multiplication(fc, sp)
 end

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -297,6 +297,13 @@ using Static
             M = @inferred Multiplication(Fun(L), NormalizedPolynomialSpace(L))
             @test M * Fun(NormalizedLegendre()) ≈ Fun(x->x^2, NormalizedLegendre())
         end
+
+        M1 = @inferred Multiplication(Fun(Legendre()), NormalizedLegendre())
+        @test M1 * Fun(x->x^4, NormalizedLegendre()) ≈ Fun(x->x^5, NormalizedLegendre())
+        M2 = @inferred Multiplication(Fun(NormalizedLegendre()), Legendre())
+        @test M2 * Fun(x->x^4, Legendre()) ≈ Fun(x->x^5, Legendre())
+        M3 = @inferred Multiplication(Fun(NormalizedLegendre()), NormalizedLegendre())
+        @test M3 * Fun(x->x^4, NormalizedLegendre()) ≈ Fun(x->x^5, NormalizedLegendre())
     end
 
     @testset "Jacobi integrate and sum" begin


### PR DESCRIPTION
After this, the following is type-inferred:
```julia
julia> @inferred Multiplication(Fun(Legendre()), NormalizedLegendre())
MultiplicationWrapper : NormalizedLegendre() → NormalizedLegendre()
 0.0      0.57735    ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
 0.57735  0.0       0.516398   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅       0.516398  0.0       0.507093   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅        ⋅        0.507093  0.0       0.503953   ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅        ⋅         ⋅        0.503953  0.0       0.502519   ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅        ⋅         ⋅         ⋅        0.502519  0.0       0.501745   ⋅         ⋅         ⋅        ⋅
  ⋅        ⋅         ⋅         ⋅         ⋅        0.501745  0.0       0.50128    ⋅         ⋅        ⋅
  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅        0.50128   0.0       0.500979   ⋅        ⋅
  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.500979  0.0       0.500773  ⋅
  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.500773  0.0       ⋱
  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋱        ⋱
```