### PR TITLE
Derivative in normalized polynomial spaces

### DIFF
--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -571,3 +571,11 @@ function Multiplication(f::Fun{<:NormalizedPolynomialSpace}, sp::NormalizedPolyn
     fc = ConcreteConversion(space(f), canonicalspace(f))*f
     Multiplication(fc, sp)
 end
+
+function Derivative(sp::NormalizedPolynomialSpace, k::Number)
+    assert_integer(k)
+    csp=canonicalspace(sp)
+    D = Derivative(csp,k)
+    C = ConcreteConversion(sp,csp)
+    DerivativeWrapper(TimesOperator(D, C), sp, k)
+end

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -226,8 +226,12 @@ using Static
         # only one band should be populated
         @test bandwidths(D, 1) == -bandwidths(D, 2)
 
-        @test !isdiag(Derivative(Legendre()))
-        @test !isdiag(Derivative(NormalizedLegendre()))
+        @test !isdiag(@inferred Derivative(Legendre()))
+        T1 = typeof(Derivative(Legendre()))
+        T2 = typeof(Derivative(Legendre(), 2))
+        @test !isdiag(@inferred Union{T1,T2} Derivative(Legendre()))
+        @test !isdiag(@inferred Derivative(NormalizedLegendre()))
+        @test !isdiag(@inferred Derivative(NormalizedLegendre(), 2))
 
         @testset for d in [-1..1, 0..1]
             f = Fun(x->x^2, Chebyshev(d))


### PR DESCRIPTION
This makes the following type-stable:
```julia
julia> @inferred Derivative(NormalizedLegendre(), 2)
DerivativeWrapper : NormalizedLegendre() → Jacobi(2,2)
 ⋅  ⋅  4.74342   ⋅         ⋅        ⋅        ⋅        ⋅       ⋅        ⋅      ⋅
 ⋅  ⋅   ⋅       9.35414    ⋅        ⋅        ⋅        ⋅       ⋅        ⋅      ⋅
 ⋅  ⋅   ⋅        ⋅       15.9099    ⋅        ⋅        ⋅       ⋅        ⋅      ⋅
 ⋅  ⋅   ⋅        ⋅         ⋅      24.6247    ⋅        ⋅       ⋅        ⋅      ⋅
 ⋅  ⋅   ⋅        ⋅         ⋅        ⋅      35.6931    ⋅       ⋅        ⋅      ⋅
 ⋅  ⋅   ⋅        ⋅         ⋅        ⋅        ⋅      49.295    ⋅        ⋅      ⋅
 ⋅  ⋅   ⋅        ⋅         ⋅        ⋅        ⋅        ⋅     65.5982    ⋅      ⋅
 ⋅  ⋅   ⋅        ⋅         ⋅        ⋅        ⋅        ⋅       ⋅      84.7607  ⋅
 ⋅  ⋅   ⋅        ⋅         ⋅        ⋅        ⋅        ⋅       ⋅        ⋅      ⋱
 ⋅  ⋅   ⋅        ⋅         ⋅        ⋅        ⋅        ⋅       ⋅        ⋅      ⋱
 ⋅  ⋅   ⋅        ⋅         ⋅        ⋅        ⋅        ⋅       ⋅        ⋅      ⋱
```