### PR TITLE
use NTuple{2,UnitRange{Int}}

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.6.14"
+version = "0.6.15"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/src/Spaces/Chebyshev/ChebyshevOperators.jl
+++ b/src/Spaces/Chebyshev/ChebyshevOperators.jl
@@ -148,7 +148,7 @@ function getindex(op::ConcreteDirichlet{<:Chebyshev},
 end
 
 function Matrix(S::SubOperator{T,ConcreteDirichlet{C,V,T},
-                                Tuple{UnitRange{Int},UnitRange{Int}}}) where {C<:Chebyshev,V,T}
+                                NTuple{2,UnitRange{Int}}}) where {C<:Chebyshev,V,T}
     ret = Array{T}(undef, size(S)...)
     kr,jr = parentindices(S)
     isempty(kr) && return ret
@@ -181,7 +181,7 @@ getindex(M::ConcreteMultiplication{C,PS,T},k::Integer,j::Integer) where {PS<:Pol
     M[k:k,j:j][1,1]
 
 
-function BandedMatrix(S::SubOperator{T,ConcreteMultiplication{C,C,T},Tuple{UnitRange{Int},UnitRange{Int}}}) where {C<:Chebyshev,T}
+function BandedMatrix(S::SubOperator{T,ConcreteMultiplication{C,C,T},NTuple{2,UnitRange{Int}}}) where {C<:Chebyshev,T}
     ret = BandedMatrix(Zeros, S)
 
     kr,jr=parentindices(S)

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -250,7 +250,7 @@ function jac_gbmm!(α, J, B, β, C, b, valJ, valBC)
 end
 
 function BandedMatrix(S::SubOperator{T,ConcreteMultiplication{C,PS,T},
-                                     Tuple{UnitRange{Int},UnitRange{Int}}}) where {PS<:PolynomialSpace,T,C<:PolynomialSpace}
+                                     NTuple{2,UnitRange{Int}}}) where {PS<:PolynomialSpace,T,C<:PolynomialSpace}
     M=parent(S)
     kr,jr=parentindices(S)
     f=M.f

--- a/src/Spaces/Ultraspherical/ContinuousSpace.jl
+++ b/src/Spaces/Ultraspherical/ContinuousSpace.jl
@@ -287,7 +287,7 @@ end
 
 
 function BlockBandedMatrix(S::SubOperator{T,<:ConcreteDirichlet{<:TensorChebyshevDirichlet},
-                                Tuple{UnitRange{Int},UnitRange{Int}}}) where {T}
+                                NTuple{2,UnitRange{Int}}}) where {T}
     P=parent(S)
     ret=BlockBandedMatrix(Zeros, S)
     kr,jr=parentindices(S)

--- a/src/fastops.jl
+++ b/src/fastops.jl
@@ -11,7 +11,7 @@
 #####
 
 function BandedMatrix(S::SubOperator{T,ConcreteConversion{Chebyshev{DD,RR},Ultraspherical{Int,DD,RR},T},
-                              Tuple{UnitRange{Int},UnitRange{Int}}}) where {T,DD,RR}
+                              NTuple{2,UnitRange{Int}}}) where {T,DD,RR}
     # we can assume order is 1
     ret = BandedMatrix{eltype(S)}(undef, size(S), bandwidths(S))
     kr,jr = parentindices(S)
@@ -32,7 +32,7 @@ function BandedMatrix(S::SubOperator{T,ConcreteConversion{Chebyshev{DD,RR},Ultra
 end
 
 function BandedMatrix(V::SubOperator{T,ConcreteConversion{Ultraspherical{LT,DD,RR},Ultraspherical{LT,DD,RR},T},
-                                                                  Tuple{UnitRange{Int},UnitRange{Int}}}) where {T,LT,DD,RR}
+                                                                  NTuple{2,UnitRange{Int}}}) where {T,LT,DD,RR}
 
     n,m = size(V)
     V_l, V_u = bandwidths(V)
@@ -66,7 +66,7 @@ end
 
 
 function BandedMatrix(S::SubOperator{T,ConcreteDerivative{Chebyshev{DD,RR},K,T},
-                                                     Tuple{UnitRange{Int},UnitRange{Int}}}) where {T,K,DD,RR}
+                                                     NTuple{2,UnitRange{Int}}}) where {T,K,DD,RR}
 
     n,m = size(S)
     ret = BandedMatrix{eltype(S)}(undef, (n,m), bandwidths(S))
@@ -92,7 +92,7 @@ end
 
 
 function BandedMatrix(S::SubOperator{T,ConcreteDerivative{Ultraspherical{LT,DD,RR},K,T},
-                                                  Tuple{UnitRange{Int},UnitRange{Int}}}) where {T,K,DD,RR,LT}
+                                                  NTuple{2,UnitRange{Int}}}) where {T,K,DD,RR,LT}
     n,m = size(S)
     ret = BandedMatrix{eltype(S)}(undef, (n,m), bandwidths(S))
     kr,jr = parentindices(S)


### PR DESCRIPTION
Purely stylistic change to replace `Tuple{UnitRange{Int},UnitRange{Int}}` by `NTuple{2,UnitRange{Int}}`