### PR TITLE
Use `==` for Integer in spacescompatible

### DIFF
--- a/src/ApproxFunOrthogonalPolynomials.jl
+++ b/src/ApproxFunOrthogonalPolynomials.jl
@@ -121,6 +121,13 @@ convert_vector_or_svector(t::Tuple) = SVector(t)
 
 const TupleOrVector{T} = Union{Tuple{T,Vararg{T}},AbstractVector{<:T}}
 
+# If any of the orders is an Integer, use == for an exact comparison, else fall back to isapprox
+# We assume that Integer orders are deliberately chosen to be exact
+compare_op(::Integer, args...) = ==
+compare_op() = ≈
+compare_op(::Any, args...) = compare_op(args...)
+compare_orders(a::Number, b::Number) = compare_op(a, b)(a, b)
+
 include("bary.jl")
 
 

--- a/src/Spaces/Jacobi/Jacobi.jl
+++ b/src/Spaces/Jacobi/Jacobi.jl
@@ -41,13 +41,7 @@ Base.promote_rule(::Type{Jacobi{D,R1,T1}},::Type{Jacobi{D,R2,T2}}) where {D,R1,R
 convert(::Type{Jacobi{D,R1,T1}},J::Jacobi{D,R2,T2}) where {D,R1,R2,T1,T2} =
     Jacobi{D,R1}(T1(J.b)::T1, T1(J.a)::T1, J.domain)::Jacobi{D,R1,T1}
 
-# If any of the orders is an Integer, use == for an exact comparison, else fall back to isapprox
-# We assume that Integer orders are deliberately chosen to be exact
-compare_op(::Integer, args...) = ==
-compare_op() = ≈
-compare_op(::Any, args...) = compare_op(args...)
-_compare_orders(a::Number, b::Number) = compare_op(a, b)(a, b)
-compare_orders((Aa, Ba)::NTuple{2,Number}, (Ab, Bb)::NTuple{2,Number}) = _compare_orders(Aa, Ba) && _compare_orders(Ab, Bb)
+compare_orders((Aa, Ba)::NTuple{2,Number}, (Ab, Bb)::NTuple{2,Number}) = compare_orders(Aa, Ba) && compare_orders(Ab, Bb)
 spacescompatible(a::Jacobi, b::Jacobi) = compare_orders((a.a, b.a), (a.b, b.b)) && domainscompatible(a,b)
 
 isapproxinteger_addhalf(a) = !isapproxinteger(a) && isapproxinteger(a+0.5)

--- a/src/Spaces/Jacobi/Jacobi.jl
+++ b/src/Spaces/Jacobi/Jacobi.jl
@@ -41,8 +41,14 @@ Base.promote_rule(::Type{Jacobi{D,R1,T1}},::Type{Jacobi{D,R2,T2}}) where {D,R1,R
 convert(::Type{Jacobi{D,R1,T1}},J::Jacobi{D,R2,T2}) where {D,R1,R2,T1,T2} =
     Jacobi{D,R1}(T1(J.b)::T1, T1(J.a)::T1, J.domain)::Jacobi{D,R1,T1}
 
-
-spacescompatible(a::Jacobi,b::Jacobi) = a.a ≈ b.a && a.b ≈ b.b && domainscompatible(a,b)
+# If any of the orders is an Integer, use == for an exact comparison, else fall back to isapprox
+# We assume that Integer orders are deliberately chosen to be exact
+compare_op(::Integer, args...) = ==
+compare_op() = ≈
+compare_op(::Any, args...) = compare_op(args...)
+_compare_orders(a::Number, b::Number) = compare_op(a, b)(a, b)
+compare_orders((Aa, Ba)::NTuple{2,Number}, (Ab, Bb)::NTuple{2,Number}) = _compare_orders(Aa, Ba) && _compare_orders(Ab, Bb)
+spacescompatible(a::Jacobi, b::Jacobi) = compare_orders((a.a, b.a), (a.b, b.b)) && domainscompatible(a,b)
 
 isapproxinteger_addhalf(a) = !isapproxinteger(a) && isapproxinteger(a+0.5)
 isapproxinteger_addhalf(::Integer) = false

--- a/src/Spaces/Laguerre/Laguerre.jl
+++ b/src/Spaces/Laguerre/Laguerre.jl
@@ -35,7 +35,7 @@ const NormalizedLaguerre{T<:Real,D<:Ray} = NormalizedPolynomialSpace{Laguerre{T,
 NormalizedLaguerre(α) = NormalizedPolynomialSpace(Laguerre(α))
 NormalizedLaguerre() = NormalizedLaguerre(0)
 
-spacescompatible(A::Laguerre,B::Laguerre) = A.α ≈ B.α && B.domain == A.domain
+spacescompatible(A::Laguerre,B::Laguerre) = compare_orders(A.α, B.α) && B.domain == A.domain
 
 canonicaldomain(::Laguerre) = Ray()
 domain(d::Laguerre) = d.domain

--- a/src/Spaces/Ultraspherical/Ultraspherical.jl
+++ b/src/Spaces/Ultraspherical/Ultraspherical.jl
@@ -128,7 +128,7 @@ end
 
 
 spacescompatible(a::Ultraspherical,b::Ultraspherical) =
-    order(a) == order(b) && domainscompatible(a,b)
+    compare_orders(order(a), order(b)) && domainscompatible(a,b)
 hasfasttransform(::Ultraspherical) = true
 
 

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -42,6 +42,15 @@ using Static
             @test ncoefficients(g) == 1
             @test coefficients(g)[1] == f(x)
         end
+
+        @testset "spacescompatible" begin
+            x = 1.0
+            y = 1.0 + eps(1.0)
+            Jx = Jacobi(x,x)
+            Jy = Jacobi(y,y)
+            @test ApproxFunBase.spacescompatible(Jx, Jy)
+            @test ApproxFunBase.spacescompatible(Ultraspherical(Jx), Ultraspherical(Jy))
+        end
     end
 
     @testset "Conversion" begin


### PR DESCRIPTION
We assume that integer orders are deliberately chosen to be so, and use an exact comparison if one of the two spaces has an integer order. If both spaces have non-integer orders, this falls back to an approximate comparison

This also makes `spacescompatible` consistent across spaces.