### PR TITLE
Add convenience functions for symmetric eigen BandedMatrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.6.26"
+version = "0.6.27"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ApproxFunBase = "0.8.21"
+ApproxFunBase = "0.8.22"
 ApproxFunBaseTest = "0.1"
 Aqua = "0.5"
 BandedMatrices = "0.16, 0.17"

--- a/src/ApproxFunOrthogonalPolynomials.jl
+++ b/src/ApproxFunOrthogonalPolynomials.jl
@@ -44,7 +44,7 @@ import ApproxFunBase: Fun, SubSpace, WeightSpace, NoSpace, HeavisideSpace,
                     ℓ⁰, recα, recβ, recγ, ℵ₀, ∞, RectDomain,
                     assert_integer, supportsinplacetransform, ContinuousSpace, SpecialEvalPtType,
                     isleftendpoint, isrightendpoint, evaluation_point, boundaryfn, ldiffbc, rdiffbc,
-                    LeftEndPoint, RightEndPoint, normalizedspace
+                    LeftEndPoint, RightEndPoint, normalizedspace, promotedomainspace
 
 import DomainSets: Domain, indomain, UnionDomain, FullSpace, Point,
             Interval, ChebyshevInterval, boundary, rightendpoint, leftendpoint,
@@ -140,6 +140,7 @@ include("Spaces/Spaces.jl")
 include("roots.jl")
 include("specialfunctions.jl")
 include("fastops.jl")
+include("symeigen.jl")
 include("show.jl")
 
 end

--- a/src/ApproxFunOrthogonalPolynomials.jl
+++ b/src/ApproxFunOrthogonalPolynomials.jl
@@ -82,7 +82,7 @@ import SpecialFunctions: erfcx, dawson,
 
 using StaticArrays: SVector
 
-import LinearAlgebra: isdiag
+import LinearAlgebra: isdiag, eigvals
 
 points(d::IntervalOrSegmentDomain{T},n::Integer) where {T} =
     _maybefromcanonical(d, chebyshevpoints(float(real(eltype(T))), n))  # eltype to handle point

--- a/src/Spaces/Jacobi/Jacobi.jl
+++ b/src/Spaces/Jacobi/Jacobi.jl
@@ -14,13 +14,18 @@ end
 Jacobi(b::T,a::T,d::Domain) where {T<:Number} =
     Jacobi{typeof(d),promote_type(T,real(prectype(d)))}(b, a, d)
 Legendre(domain = ChebyshevInterval()) = Jacobi(0,0,Domain(domain)::Domain)
+Legendre(s::PolynomialSpace) = Legendre(Jacobi(s))
+Legendre(s::Jacobi) = s.a == s.b == 0 ? s : throw(ArgumentError("can't convert $s to Legendre"))
 Jacobi(b::Number,a::Number,d=ChebyshevInterval()) = Jacobi(promote(b, a)..., Domain(d)::Domain)
 Jacobi(A::Ultraspherical) = Jacobi(order(A)-0.5,order(A)-0.5,domain(A))
 Jacobi(A::Chebyshev) = Jacobi(-0.5,-0.5,domain(A))
+Jacobi(A::Jacobi) = A
 
 const NormalizedJacobi{D<:Domain,R,T} = NormalizedPolynomialSpace{Jacobi{D,R,T},D,R}
 NormalizedJacobi(s...) = NormalizedPolynomialSpace(Jacobi(s...))
+NormalizedJacobi(s::Space) = NormalizedPolynomialSpace(Jacobi(_stripnorm(s)))
 NormalizedLegendre(d...) = NormalizedPolynomialSpace(Legendre(d...))
+NormalizedLegendre(s::Space) = NormalizedPolynomialSpace(Legendre(_stripnorm(s)))
 
 function normalization(::Type{T}, sp::Jacobi, k::Int) where T
     x = FastTransforms.Anαβ(k, sp.a, sp.b)

--- a/src/symeigen.jl
+++ b/src/symeigen.jl
@@ -1,34 +1,57 @@
-export symmetric_bandmatrices_eigen, SymmetricEigensystem
+export symmetric_bandmatrices_eigen, bandmatrices_eigen, SymmetricEigensystem, SkewSymmetricEigensystem
+
+abstract type EigenSystem end
 
 """
     SymmetricEigensystem(L::Operator, B::Operator)
 
 Represent the eigensystem `L v = λ v` subject to `B v = 0`, where `L` is self-adjoint with respect to the standard `L2`
 inner product given the boundary conditions `B`.
-The `domainspace` of the operators must be one of `Legendre(::Domain)` or `Ultraspherical(0.5, ::Domain)`.
 
 !!! note
     No tests are performed to assert that the system is self-adjoint, and it's the user's responsibility
     to ensure that the operators are compliant.
 """
-struct SymmetricEigensystem{LT,QT}
-    L :: LT
-    Q :: QT
+SymmetricEigensystem
 
-    function SymmetricEigensystem(L, B)
-        L2, B2 = promotedomainspace((L, B))
-        if isambiguous(domainspace(L))
-            throw(ArgumentError("could not detect spaces, please specify the domain spaces for the operators"))
+"""
+    SkewSymmetricEigensystem(L::Operator, B::Operator)
+
+Represent the eigensystem `L v = λ v` subject to `B v = 0`, where `L` is skew-symmetric with respect to the standard `L2`
+inner product given the boundary conditions `B`.
+
+!!! note
+    No tests are performed to assert that the system is skew-symmetric, and it's the user's responsibility
+    to ensure that the operators are compliant.
+"""
+SymmetricEigensystem
+
+_quotientspace(B, ::Val{:SymmetricEigensystem}) = QuotientSpace(B)
+_quotientspace(B, ::Val{:SkewSymmetricEigensystem}) = PathologicalQuotientSpace(B)
+
+for SET in (:SymmetricEigensystem, :SkewSymmetricEigensystem)
+    qv = Val(SET)
+    @eval begin
+        struct $SET{LT,QT} <: EigenSystem
+            L :: LT
+            Q :: QT
+
+            function $SET(L, B)
+                L2, B2 = promotedomainspace((L, B))
+                if isambiguous(domainspace(L))
+                    throw(ArgumentError("could not detect spaces, please specify the domain spaces for the operators"))
+                end
+
+                QS = _quotientspace(B2, $qv)
+                S = domainspace(L2)
+                Q = Conversion(QS, S)
+                new{typeof(L2),typeof(Q)}(L2, Q)
+            end
         end
-
-        QS = QuotientSpace(B2)
-        S = domainspace(L2)
-        Q = Conversion(QS, S)
-        new{typeof(L2),typeof(Q)}(L2, Q)
     end
 end
 
-function basis_recombination(SE::SymmetricEigensystem)
+function basis_recombination(SE::EigenSystem)
     L, Q = SE.L, SE.Q
     S = domainspace(L)
     D1 = Conversion_normalizedspace(S)
@@ -48,23 +71,44 @@ end
 Recast the self-adjoint eigenvalue problem `L v = λ v` subject to `B v = 0` to the generalized
 eigenvalue problem `SA v = λ SB v`, where `SA` and `SB` are symmetric banded operators, and
 return the `n × n` matrix representations of `SA` and `SB`.
-The `domainspace` of the operators must be one of `Legendre(::Domain)` or `Ultraspherical(0.5, ::Domain)`.
 
 !!! note
     No tests are performed to assert that the system is self-adjoint, and it's the user's responsibility
     to ensure that the operators are compliant.
 """
 function symmetric_bandmatrices_eigen(L::Operator, B::Operator, n::Integer)
-    symmetric_bandmatrices_eigen(SymmetricEigensystem(L, B), n)
+    bandmatrices_eigen(SymmetricEigensystem(L, B), n)
 end
-function symmetric_bandmatrices_eigen(S::SymmetricEigensystem, n::Integer)
-    AA, BB = basis_recombination(S)
-    SA = Symmetric(AA[1:n,1:n], :L)
-    SB = Symmetric(BB[1:n,1:n], :L)
+
+function bandmatrices_eigen(S::SymmetricEigensystem, n::Integer)
+    A, B = _bandmatrices_eigen(S, n)
+    SA = Symmetric(A, :L)
+    SB = Symmetric(B, :L)
     return SA, SB
 end
 
+"""
+    bandmatrices_eigen(S::Union{SymmetricEigensystem, SkewSymmetricEigensystem}, n::Integer)
+
+Recast the symmetric/skew-symmetric eigenvalue problem `L v = λ v` subject to `B v = 0` to the generalized
+eigenvalue problem `SA v = λ SB v`, where `SA` and `SB` are banded operators, and
+return the `n × n` matrix representations of `SA` and `SB`.
+If `S isa SymmetricEigensystem`, the returned matrices will be `Symmetric`.
+
+!!! note
+    No tests are performed to assert that the system is symmetric/skew-symmetric, and it's the user's responsibility
+    to ensure that the operators are compliant.
+"""
+bandmatrices_eigen(S::EigenSystem, n::Integer) = _bandmatrices_eigen(S, n)
+
+function _bandmatrices_eigen(S::EigenSystem, n::Integer)
+    AA, BB = basis_recombination(S)
+    A = AA[1:n,1:n]
+    B = BB[1:n,1:n]
+    return A, B
+end
+
 function eigvals(S::SymmetricEigensystem, n::Integer)
-    SA, SB = symmetric_bandmatrices_eigen(S, n)
+    SA, SB = bandmatrices_eigen(S, n)
     eigvals(SA, SB)
 end

--- a/src/symeigen.jl
+++ b/src/symeigen.jl
@@ -80,13 +80,6 @@ function symmetric_bandmatrices_eigen(L::Operator, B::Operator, n::Integer)
     bandmatrices_eigen(SymmetricEigensystem(L, B), n)
 end
 
-function bandmatrices_eigen(S::SymmetricEigensystem, n::Integer)
-    A, B = _bandmatrices_eigen(S, n)
-    SA = Symmetric(A, :L)
-    SB = Symmetric(B, :L)
-    return SA, SB
-end
-
 """
     bandmatrices_eigen(S::SymmetricEigensystem, n::Integer)
 
@@ -98,6 +91,13 @@ return the `n × n` matrix representations of `SA` and `SB`.
     No tests are performed to assert that the system is self-adjoint, and it's the user's responsibility
     to ensure that the operators are compliant.
 """
+function bandmatrices_eigen(S::SymmetricEigensystem, n::Integer)
+    A, B = _bandmatrices_eigen(S, n)
+    SA = Symmetric(A, :L)
+    SB = Symmetric(B, :L)
+    return SA, SB
+end
+
 bandmatrices_eigen(S::EigenSystem, n::Integer) = _bandmatrices_eigen(S, n)
 
 function _bandmatrices_eigen(S::EigenSystem, n::Integer)

--- a/src/symeigen.jl
+++ b/src/symeigen.jl
@@ -20,11 +20,6 @@ struct SymmetricEigensystem{LT,QT}
         if isambiguous(domainspace(L))
             throw(ArgumentError("could not detect spaces, please specify the domain spaces for the operators"))
         end
-        d = domain(L2)
-        if !(domainspace(L2) == Legendre(d) || domainspace(L2) == Ultraspherical(0.5, d))
-            throw(ArgumentError("domainspace of the operators must be $(Legendre(d)) or $(Ultraspherical(0.5,d)) "*
-                "for the symmetric banded conversion, received $(domainspace(L2))"))
-        end
 
         QS = QuotientSpace(B2)
         S = domainspace(L2)
@@ -36,9 +31,8 @@ end
 function basis_recombination(SE::SymmetricEigensystem)
     L, Q = SE.L, SE.Q
     S = domainspace(L)
-    NS = NormalizedPolynomialSpace(S)
-    D1 = ConcreteConversion(S, NS)
-    D2 = ConcreteConversion(NS, S)
+    D1 = Conversion_normalizedspace(S)
+    D2 = Conversion_normalizedspace(S, Val(:backward))
     R = D1*Q;
     C = Conversion(S, rangespace(L))
     P = cache(PartialInverseOperator(C, (0, bandwidth(L, 1) + bandwidth(R, 1) + bandwidth(C, 2))));

--- a/src/symeigen.jl
+++ b/src/symeigen.jl
@@ -69,3 +69,8 @@ function symmetric_bandmatrices_eigen(S::SymmetricEigensystem, n::Integer)
     SB = Symmetric(BB[1:n,1:n], :L)
     return SA, SB
 end
+
+function eigvals(S::SymmetricEigensystem, n::Integer)
+    SA, SB = symmetric_bandmatrices_eigen(S, n)
+    eigvals(SA, SB)
+end

--- a/src/symeigen.jl
+++ b/src/symeigen.jl
@@ -29,7 +29,7 @@ end
     symmetric_bandmatrices_eigen(L::Operator, B::Operator, n::Integer)
 
 Recast the self-adjoint eigenvalue problem `L v = λ v` subject to `B v = 0` to the generalized
-eigenvalue problem `SA v = λ SB v`, where `SA` and `SB` are `Symmetric(::BandedMatrix)`es, and
+eigenvalue problem `SA v = λ SB v`, where `SA` and `SB` are symmetric banded operators, and
 return the `n × n` matrix representations of `SA` and `SB`.
 The `domainspace` of the operators must be one of `Legedre(::Domain)` or `Ultraspherical(0.5, ::Domain)`.
 

--- a/src/symeigen.jl
+++ b/src/symeigen.jl
@@ -88,15 +88,14 @@ function bandmatrices_eigen(S::SymmetricEigensystem, n::Integer)
 end
 
 """
-    bandmatrices_eigen(S::Union{SymmetricEigensystem, SkewSymmetricEigensystem}, n::Integer)
+    bandmatrices_eigen(S::SymmetricEigensystem, n::Integer)
 
-Recast the symmetric/skew-symmetric eigenvalue problem `L v = λ v` subject to `B v = 0` to the generalized
-eigenvalue problem `SA v = λ SB v`, where `SA` and `SB` are banded operators, and
+Recast the self-adjoint eigenvalue problem `L v = λ v` subject to `B v = 0` to the generalized
+eigenvalue problem `SA v = λ SB v`, where `SA` and `SB` are symmetric banded operators, and
 return the `n × n` matrix representations of `SA` and `SB`.
-If `S isa SymmetricEigensystem`, the returned matrices will be `Symmetric`.
 
 !!! note
-    No tests are performed to assert that the system is symmetric/skew-symmetric, and it's the user's responsibility
+    No tests are performed to assert that the system is self-adjoint, and it's the user's responsibility
     to ensure that the operators are compliant.
 """
 bandmatrices_eigen(S::EigenSystem, n::Integer) = _bandmatrices_eigen(S, n)

--- a/src/symeigen.jl
+++ b/src/symeigen.jl
@@ -102,7 +102,7 @@ function bandmatrices_eigen(S::EigenSystem, n::Integer)
     A, B = _bandmatrices_eigen(S, n)
     A2 = tril(A, bandwidth(A,1))
     B2 = tril(B, bandwidth(B,1))
-    A2, B2
+    Matrix(A2), Matrix(B2)
 end
 
 function _bandmatrices_eigen(S::EigenSystem, n::Integer)

--- a/src/symeigen.jl
+++ b/src/symeigen.jl
@@ -30,8 +30,8 @@ end
 
 Recast the self-adjoint eigenvalue problem `L v = λ v` subject to `B v = 0` to the generalized
 eigenvalue problem `SA v = λ SB v`, where `SA` and `SB` are `Symmetric(::BandedMatrix)`es, and
-return `SA` and `SB`. The `domainspace` of the operators must be one of `Legedre(::Domain)` or
-`Ultraspherical(0.5, ::Domain)`.
+return the `n × n` matrix representations of `SA` and `SB`.
+The `domainspace` of the operators must be one of `Legedre(::Domain)` or `Ultraspherical(0.5, ::Domain)`.
 
 !!! note
     No tests are performed to assert that the system is self-adjoint, and it's the user's responsibility

--- a/src/symeigen.jl
+++ b/src/symeigen.jl
@@ -1,4 +1,4 @@
-export symmetric_bandmatrices_eigen, bandmatrices_eigen, SymmetricEigensystem, SkewSymmetricEigensystem
+export bandmatrices_eigen, SymmetricEigensystem, SkewSymmetricEigensystem
 
 abstract type EigenSystem end
 
@@ -80,29 +80,15 @@ function basis_recombination(SE::EigenSystem)
 end
 
 """
-    symmetric_bandmatrices_eigen(L::Operator, B::Operator, n::Integer)
+    bandmatrices_eigen(S::Union{SymmetricEigensystem, SkewSymmetricEigensystem}, n::Integer)
 
-Recast the self-adjoint eigenvalue problem `L v = λ v` subject to `B v = 0` to the generalized
-eigenvalue problem `SA v = λ SB v`, where `SA` and `SB` are symmetric banded operators, and
+Recast the symmetric/skew-symmetric eigenvalue problem `L v = λ v` subject to `B v = 0` to the generalized
+eigenvalue problem `SA v = λ SB v`, where `SA` and `SB` are banded operators, and
 return the `n × n` matrix representations of `SA` and `SB`.
+If `S isa SymmetricEigensystem`, the returned matrices will be `Symmetric`.
 
 !!! note
-    No tests are performed to assert that the system is self-adjoint, and it's the user's responsibility
-    to ensure that the operators are compliant.
-"""
-function symmetric_bandmatrices_eigen(L::Operator, B::Operator, n::Integer)
-    bandmatrices_eigen(SymmetricEigensystem(L, B), n)
-end
-
-"""
-    bandmatrices_eigen(S::SymmetricEigensystem, n::Integer)
-
-Recast the self-adjoint eigenvalue problem `L v = λ v` subject to `B v = 0` to the generalized
-eigenvalue problem `SA v = λ SB v`, where `SA` and `SB` are symmetric banded operators, and
-return the `n × n` matrix representations of `SA` and `SB`.
-
-!!! note
-    No tests are performed to assert that the system is self-adjoint, and it's the user's responsibility
+    No tests are performed to assert that the system is symmetric/skew-symmetric, and it's the user's responsibility
     to ensure that the operators are compliant.
 """
 function bandmatrices_eigen(S::SymmetricEigensystem, n::Integer)
@@ -126,7 +112,7 @@ function _bandmatrices_eigen(S::EigenSystem, n::Integer)
     return A, B
 end
 
-function eigvals(S::SymmetricEigensystem, n::Integer)
+function eigvals(S::EigenSystem, n::Integer)
     SA, SB = bandmatrices_eigen(S, n)
     eigvals(SA, SB)
 end

--- a/src/symeigen.jl
+++ b/src/symeigen.jl
@@ -1,25 +1,48 @@
-export symmetric_bandmatrices_eigen
+export symmetric_bandmatrices_eigen, SymmetricEigensystem
 
-function symmetrize_operator_eigen(L, B)
-    L2, B2 = promotedomainspace((L, B))
-    if isambiguous(domainspace(L))
-        throw(ArgumentError("could not detect spaces, please specify the domain spaces for the operators"))
+"""
+    SymmetricEigensystem(L::Operator, B::Operator)
+
+Represent the eigensystem `L v = λ v` subject to `B v = 0`, where `L` is self-adjoint with respect to the standard `L2`
+inner product given the boundary conditions `B`.
+The `domainspace` of the operators must be one of `Legendre(::Domain)` or `Ultraspherical(0.5, ::Domain)`.
+
+!!! note
+    No tests are performed to assert that the system is self-adjoint, and it's the user's responsibility
+    to ensure that the operators are compliant.
+"""
+struct SymmetricEigensystem{LT,QT}
+    L :: LT
+    Q :: QT
+
+    function SymmetricEigensystem(L, B)
+        L2, B2 = promotedomainspace((L, B))
+        if isambiguous(domainspace(L))
+            throw(ArgumentError("could not detect spaces, please specify the domain spaces for the operators"))
+        end
+        d = domain(L2)
+        if !(domainspace(L2) == Legendre(d) || domainspace(L2) == Ultraspherical(0.5, d))
+            throw(ArgumentError("domainspace of the operators must be $(Legendre(d)) or $(Ultraspherical(0.5,d)) "*
+                "for the symmetric banded conversion, received $(domainspace(L2))"))
+        end
+
+        QS = QuotientSpace(B2)
+        S = domainspace(L2)
+        Q = Conversion(QS, S)
+        new{typeof(L2),typeof(Q)}(L2, Q)
     end
-    d = domain(L2)
-    if !(domainspace(L2) == Legendre(d) || domainspace(L2) == Ultraspherical(0.5, d))
-        throw(ArgumentError("domainspace of the operators must be $(Legendre(d)) or $(Ultraspherical(0.5,d)) "*
-            "for the symmetric banded conversion, received $(domainspace(L2))"))
-    end
-    S = domainspace(L2)
+end
+
+function basis_recombination(SE::SymmetricEigensystem)
+    L, Q = SE.L, SE.Q
+    S = domainspace(L)
     NS = NormalizedPolynomialSpace(S)
-    D1 = Conversion(S, NS)
-    D2 = Conversion(NS, S);
-    QS = QuotientSpace(B2)
-    Q = Conversion(QS, S)
+    D1 = ConcreteConversion(S, NS)
+    D2 = ConcreteConversion(NS, S)
     R = D1*Q;
-    C = Conversion(domainspace(L2), rangespace(L2))
-    P = cache(PartialInverseOperator(C, (0, bandwidth(L2, 1) + bandwidth(R, 1) + bandwidth(C, 2))));
-    A = R'D1*P*L2*D2*R
+    C = Conversion(S, rangespace(L))
+    P = cache(PartialInverseOperator(C, (0, bandwidth(L, 1) + bandwidth(R, 1) + bandwidth(C, 2))));
+    A = R'D1*P*L*D2*R
     BB = R'R;
 
     return A, BB
@@ -31,14 +54,17 @@ end
 Recast the self-adjoint eigenvalue problem `L v = λ v` subject to `B v = 0` to the generalized
 eigenvalue problem `SA v = λ SB v`, where `SA` and `SB` are symmetric banded operators, and
 return the `n × n` matrix representations of `SA` and `SB`.
-The `domainspace` of the operators must be one of `Legedre(::Domain)` or `Ultraspherical(0.5, ::Domain)`.
+The `domainspace` of the operators must be one of `Legendre(::Domain)` or `Ultraspherical(0.5, ::Domain)`.
 
 !!! note
     No tests are performed to assert that the system is self-adjoint, and it's the user's responsibility
-    to ensure that this holds.
+    to ensure that the operators are compliant.
 """
-function symmetric_bandmatrices_eigen(L, B, n)
-    AA, BB = symmetrize_operator_eigen(L, B)
+function symmetric_bandmatrices_eigen(L::Operator, B::Operator, n::Integer)
+    symmetric_bandmatrices_eigen(SymmetricEigensystem(L, B), n)
+end
+function symmetric_bandmatrices_eigen(S::SymmetricEigensystem, n::Integer)
+    AA, BB = basis_recombination(S)
     SA = Symmetric(AA[1:n,1:n], :L)
     SB = Symmetric(BB[1:n,1:n], :L)
     return SA, SB

--- a/src/symeigen.jl
+++ b/src/symeigen.jl
@@ -3,46 +3,60 @@ export symmetric_bandmatrices_eigen, bandmatrices_eigen, SymmetricEigensystem, S
 abstract type EigenSystem end
 
 """
-    SymmetricEigensystem(L::Operator, B::Operator)
+    SymmetricEigensystem(L::Operator, B::Operator, QuotientSpaceType::Type = QuotientSpace)
 
 Represent the eigensystem `L v = λ v` subject to `B v = 0`, where `L` is self-adjoint with respect to the standard `L2`
 inner product given the boundary conditions `B`.
 
 !!! note
-    No tests are performed to assert that the system is self-adjoint, and it's the user's responsibility
+    No tests are performed to assert that the operator `L` is self-adjoint, and it's the user's responsibility
     to ensure that the operators are compliant.
+
+The optional argument `QuotientSpaceType` specifies the type of space to be used to denote the quotient space in the basis
+recombination process. In most cases, the default choice of `QuotientSpace` is a good one. In specific instances where `B`
+is rank-deficient (e.g. it contains a column of zeros,
+which typically happens if one of the basis elements already satiafies the boundary conditions),
+one may need to choose this to be a `PathologicalQuotientSpace`.
+
+!!! note
+    No checks on the rank of `B` are carried out, and it's up to the user to specify the correct type.
 """
 SymmetricEigensystem
 
 """
-    SkewSymmetricEigensystem(L::Operator, B::Operator)
+    SkewSymmetricEigensystem(L::Operator, B::Operator, QuotientSpaceType::Type = QuotientSpace)
 
 Represent the eigensystem `L v = λ v` subject to `B v = 0`, where `L` is skew-symmetric with respect to the standard `L2`
 inner product given the boundary conditions `B`.
 
 !!! note
-    No tests are performed to assert that the system is skew-symmetric, and it's the user's responsibility
+    No tests are performed to assert that the operator `L` is skew-symmetric, and it's the user's responsibility
     to ensure that the operators are compliant.
-"""
-SymmetricEigensystem
 
-_quotientspace(B, ::Val{:SymmetricEigensystem}) = QuotientSpace(B)
-_quotientspace(B, ::Val{:SkewSymmetricEigensystem}) = PathologicalQuotientSpace(B)
+The optional argument `QuotientSpaceType` specifies the type of space to be used to denote the quotient space in the basis
+recombination process. In most cases, the default choice of `QuotientSpace` is a good one. In specific instances where `B`
+is rank-deficient (e.g. it contains a column of zeros,
+which typically happens if one of the basis elements already satiafies the boundary conditions),
+one may need to choose this to be a `PathologicalQuotientSpace`.
+
+!!! note
+    No checks on the rank of `B` are carried out, and it's up to the user to specify the correct type.
+"""
+SkewSymmetricEigensystem
 
 for SET in (:SymmetricEigensystem, :SkewSymmetricEigensystem)
-    qv = Val(SET)
     @eval begin
         struct $SET{LT,QT} <: EigenSystem
             L :: LT
             Q :: QT
 
-            function $SET(L, B)
+            function $SET(L, B, ::Type{QST} = QuotientSpace) where {QST}
                 L2, B2 = promotedomainspace((L, B))
                 if isambiguous(domainspace(L))
                     throw(ArgumentError("could not detect spaces, please specify the domain spaces for the operators"))
                 end
 
-                QS = _quotientspace(B2, $qv)
+                QS = QST(B2)
                 S = domainspace(L2)
                 Q = Conversion(QS, S)
                 new{typeof(L2),typeof(Q)}(L2, Q)
@@ -98,7 +112,12 @@ function bandmatrices_eigen(S::SymmetricEigensystem, n::Integer)
     return SA, SB
 end
 
-bandmatrices_eigen(S::EigenSystem, n::Integer) = _bandmatrices_eigen(S, n)
+function bandmatrices_eigen(S::EigenSystem, n::Integer)
+    A, B = _bandmatrices_eigen(S, n)
+    A2 = tril(A, bandwidth(A,1))
+    B2 = tril(B, bandwidth(B,1))
+    A2, B2
+end
 
 function _bandmatrices_eigen(S::EigenSystem, n::Integer)
     AA, BB = basis_recombination(S)

--- a/src/symeigen.jl
+++ b/src/symeigen.jl
@@ -1,0 +1,45 @@
+export symmetric_bandmatrices_eigen
+
+function symmetrize_operator_eigen(L, B)
+    L2, B2 = promotedomainspace((L, B))
+    if isambiguous(domainspace(L))
+        throw(ArgumentError("could not detect spaces, please specify the domain spaces for the operators"))
+    end
+    d = domain(L2)
+    if !(domainspace(L2) == Legendre(d) || domainspace(L2) == Ultraspherical(0.5, d))
+        throw(ArgumentError("domainspace of the operators must be $(Legendre(d)) or $(Ultraspherical(0.5,d)) "*
+            "for the symmetric banded conversion, received $(domainspace(L2))"))
+    end
+    S = domainspace(L2)
+    NS = NormalizedPolynomialSpace(S)
+    D1 = Conversion(S, NS)
+    D2 = Conversion(NS, S);
+    QS = QuotientSpace(B2)
+    Q = Conversion(QS, S)
+    R = D1*Q;
+    C = Conversion(domainspace(L2), rangespace(L2))
+    P = cache(PartialInverseOperator(C, (0, bandwidth(L2, 1) + bandwidth(R, 1) + bandwidth(C, 2))));
+    A = R'D1*P*L2*D2*R
+    BB = R'R;
+
+    return A, BB
+end
+
+"""
+    symmetric_bandmatrices_eigen(L::Operator, B::Operator, n::Integer)
+
+Recast the self-adjoint eigenvalue problem `L v = λ v` subject to `B v = 0` to the generalized
+eigenvalue problem `SA v = λ SB v`, where `SA` and `SB` are `Symmetric(::BandedMatrix)`es, and
+return `SA` and `SB`. The `domainspace` of the operators must be one of `Legedre(::Domain)` or
+`Ultraspherical(0.5, ::Domain)`.
+
+!!! note
+    No tests are performed to assert that the system is self-adjoint, and it's the user's responsibility
+    to ensure that this holds.
+"""
+function symmetric_bandmatrices_eigen(L, B, n)
+    AA, BB = symmetrize_operator_eigen(L, B)
+    SA = Symmetric(AA[1:n,1:n], :L)
+    SB = Symmetric(BB[1:n,1:n], :L)
+    return SA, SB
+end

--- a/test/EigTest.jl
+++ b/test/EigTest.jl
@@ -227,8 +227,13 @@ using Test
             L = -Derivative(S)^2
             B = Dirichlet()
             SA, SB = ApproxFunOrthogonalPolynomials.symmetric_bandmatrices_eigen(L, B, 20)
-            λ = eigvals(SA, SB)[1:4]
-            @test λ ≈ (1:4).^2 .* pi^2 rtol=1e-8
+            λ = if VERSION >= v"1.8"
+                eigvals(SA, SB)
+            else
+                # workaround for BandedMatrices bug on v1.6
+                eigvals(Matrix(SA), Matrix(SB))
+            end
+            @test λ[1:4] ≈ (1:4).^2 .* pi^2 rtol=1e-8
         end
     end
 end

--- a/test/EigTest.jl
+++ b/test/EigTest.jl
@@ -2,6 +2,7 @@ using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
 using ApproxFunBase: bandwidth
 using BandedMatrices
+using LinearAlgebra
 using SpecialFunctions
 using Test
 
@@ -226,11 +227,12 @@ using Test
         for S in Any[Legendre(0..1), Ultraspherical(0.5, 0..1)]
             L = -Derivative(S)^2
             B = Dirichlet()
-            SA, SB = ApproxFunOrthogonalPolynomials.symmetric_bandmatrices_eigen(L, B, 20)
+            Seg = SymmetricEigensystem(L, B)
             λ = if VERSION >= v"1.8"
-                eigvals(SA, SB)
+                eigvals(Seg, 20)
             else
                 # workaround for BandedMatrices bug on v1.6
+                SA, SB = ApproxFunOrthogonalPolynomials.symmetric_bandmatrices_eigen(L, B, 20)
                 eigvals(Matrix(SA), Matrix(SB))
             end
             @test λ[1:4] ≈ (1:4).^2 .* pi^2 rtol=1e-8

--- a/test/EigTest.jl
+++ b/test/EigTest.jl
@@ -221,4 +221,12 @@ using Test
         λ = eigvals(Matrix([B;L][1:n,1:n]), Matrix([B-B;C][1:n,1:n]))
         @test eltype(λ) == Complex{Float64}
     end
+
+    @testset "convenience function for symmetric problems" begin
+        L = -Derivative(Legendre(0..1))^2
+        B = Dirichlet()
+        SA, SB = ApproxFunOrthogonalPolynomials.symmetric_bandmatrices_eigen(L, B, 20)
+        λ = eigvals(SA, SB)[1:4]
+        @test λ ≈ (1:4).^2 .* pi^2 rtol=1e-8
+    end
 end

--- a/test/EigTest.jl
+++ b/test/EigTest.jl
@@ -37,7 +37,7 @@ using Test
         # where V = 100|x|.
         #
         d = Segment(-1..0)∪Segment(0..1)
-        S = PiecewiseSpace(Ultraspherical.(0.5, d.domains))
+        S = PiecewiseSpace(Ultraspherical.(0.5, components(d)))
         V = 100Fun(abs, S)
         L = -Derivative(S, 2) + V
         B = [Dirichlet(S); continuity(S, 0:1)]
@@ -55,8 +55,8 @@ using Test
         #
         # where V = 1000[χ_[-1,-1/2](x) + χ_[1/2,1](x)].
         #
-        d = Segment(-1..(-0.5))∪Segment(-0.5..0.5)∪Segment(0.5..1)
-        S = PiecewiseSpace(Ultraspherical.(0.5, d.domains))
+        d = Segment(-1..(-0.5)) ∪ Segment(-0.5..0.5) ∪ Segment(0.5..1)
+        S = PiecewiseSpace(Ultraspherical.(0.5, components(d)))
 
         V = Fun(x->abs(x) ≥ 1/2 ? 1000 : 0, S)
         L = -Derivative(S, 2) + V
@@ -77,8 +77,8 @@ using Test
         #
         # where V = x + 100δ(x-0.25).
         #
-        d = Segment(-1..0.25)∪Segment(0.25..1)
-        S = PiecewiseSpace(Ultraspherical.(0.5, d.domains))
+        d = Segment(-1..0.25) ∪ Segment(0.25..1)
+        S = PiecewiseSpace(Ultraspherical.(0.5, components(d)))
         V = Fun(identity, S)
         L = -Derivative(S, 2) + V
 
@@ -98,7 +98,7 @@ using Test
         λ, Q = eigen(SA, SB);
         u_QS = Fun(QS, Q[:, k])
         u_S = Fun(u_QS, S)
-        u = Fun(u_S, PiecewiseSpace(Chebyshev.(d.domains)))
+        u = Fun(u_S, PiecewiseSpace(Chebyshev.(components(d))))
         u /= sign(u'(-1))
         u1, u2 = components(u)
 

--- a/test/EigTest.jl
+++ b/test/EigTest.jl
@@ -223,10 +223,12 @@ using Test
     end
 
     @testset "convenience function for symmetric problems" begin
-        L = -Derivative(Legendre(0..1))^2
-        B = Dirichlet()
-        SA, SB = ApproxFunOrthogonalPolynomials.symmetric_bandmatrices_eigen(L, B, 20)
-        λ = eigvals(SA, SB)[1:4]
-        @test λ ≈ (1:4).^2 .* pi^2 rtol=1e-8
+        for S in Any[Legendre(0..1), Ultraspherical(0.5, 0..1)]
+            L = -Derivative(S)^2
+            B = Dirichlet()
+            SA, SB = ApproxFunOrthogonalPolynomials.symmetric_bandmatrices_eigen(L, B, 20)
+            λ = eigvals(SA, SB)[1:4]
+            @test λ ≈ (1:4).^2 .* pi^2 rtol=1e-8
+        end
     end
 end

--- a/test/EigTest.jl
+++ b/test/EigTest.jl
@@ -146,11 +146,11 @@ using Test
         S = Ultraspherical(0.5, d)
         Lsk = Derivative(S)
         B = Evaluation(S, -1) + Evaluation(S, 1)
-        Seig = SkewSymmetricEigensystem(Lsk, B)
+        Seig = SkewSymmetricEigensystem(Lsk, B, PathologicalQuotientSpace)
 
         n = 100
         Ask, Bsk = bandmatrices_eigen(Seig, n)
-        λ = eigvals(Matrix(tril(Ask, 1)), Matrix(tril(Bsk, 2)))
+        λ = eigvals(Ask, Bsk)
         λim = imag(sort!(λ, by = abs))
 
         @test abs.(λim[1:2:round(Int, 2n/5)]) ≈ π.*(0.5:round(Int, 2n/5)/2)

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -183,7 +183,7 @@ using Static
         end
 
         @testset "conversion between spaces" begin
-            for u in (Ultraspherical(1), Chebyshev())
+            for u in (Ultraspherical(1), Chebyshev(), Jacobi(1,1), Legendre())
                 @test NormalizedPolynomialSpace(Jacobi(u)) ==
                     NormalizedJacobi(NormalizedPolynomialSpace(u))
             end
@@ -192,13 +192,30 @@ using Static
                     NormalizedUltraspherical(NormalizedPolynomialSpace(j))
             end
 
-            @test conversion_type(NormalizedLegendre(), Jacobi(1,1)) == NormalizedLegendre()
-            @test conversion_type(Jacobi(1,1), NormalizedLegendre()) == NormalizedLegendre()
-            @test conversion_type(Jacobi(1,1), NormalizedJacobi(2,2)) == Jacobi(1,1)
-            @test conversion_type(NormalizedJacobi(2,2), Jacobi(1,1)) == Jacobi(1,1)
+            @testset "conversion_type for NormalizedPolynomialSpace" begin
+                @test conversion_type(NormalizedLegendre(), Jacobi(1,1)) == NormalizedLegendre()
+                @test conversion_type(Jacobi(1,1), NormalizedLegendre()) == NormalizedLegendre()
+                @test conversion_type(Jacobi(1,1), NormalizedJacobi(2,2)) == Jacobi(1,1)
+                @test conversion_type(NormalizedJacobi(2,2), Jacobi(1,1)) == Jacobi(1,1)
+            end
+
+            @testset "NormalizedPolynomialSpace constructor" begin
+                @test NormalizedLegendre(NormalizedLegendre()) == NormalizedLegendre()
+                @test NormalizedJacobi(NormalizedJacobi(1,1)) == NormalizedJacobi(1,1)
+                @test Legendre(Legendre()) == Legendre()
+                @test Legendre(Ultraspherical(0.5)) == Legendre()
+                @test_throws ArgumentError Legendre(Chebyshev())
+            end
         end
 
         @test ApproxFunOrthogonalPolynomials.normalization(ComplexF64, Jacobi(-0.5, -0.5), 0) ≈ pi
+
+        @testset "domainspace promotion bug" begin
+            X = Multiplication(Fun(Legendre()), NormalizedLegendre()) → Jacobi(2,2)
+            Y = X : Legendre()
+            @test domainspace(Y) == Legendre()
+            @test Y * Fun(Legendre()) ≈ Fun(x->x^2, Legendre())
+        end
     end
 
     @testset "inplace transform" begin


### PR DESCRIPTION
This provides a convenient function for the Aurentz-Slevinsky eigenvalue problem symmetrization.

After this
```julia
L = -Derivative(Legendre(0..1))^2
B = Dirichlet()
S = ApproxFun.SymmetricEigensystem(L, B);
λ = eigvals(S,20); # return 20 eigenvalues
```