### PR TITLE
Extend `normalizedspace` for `PolynomialSpace`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ApproxFunBase = "0.8.16"
+ApproxFunBase = "0.8.21"
 ApproxFunBaseTest = "0.1"
 Aqua = "0.5"
 BandedMatrices = "0.16, 0.17"

--- a/src/ApproxFunOrthogonalPolynomials.jl
+++ b/src/ApproxFunOrthogonalPolynomials.jl
@@ -44,7 +44,7 @@ import ApproxFunBase: Fun, SubSpace, WeightSpace, NoSpace, HeavisideSpace,
                     ℓ⁰, recα, recβ, recγ, ℵ₀, ∞, RectDomain,
                     assert_integer, supportsinplacetransform, ContinuousSpace, SpecialEvalPtType,
                     isleftendpoint, isrightendpoint, evaluation_point, boundaryfn, ldiffbc, rdiffbc,
-                    LeftEndPoint, RightEndPoint
+                    LeftEndPoint, RightEndPoint, normalizedspace
 
 import DomainSets: Domain, indomain, UnionDomain, FullSpace, Point,
             Interval, ChebyshevInterval, boundary, rightendpoint, leftendpoint,

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -444,7 +444,7 @@ setdomain(NS::NormalizedPolynomialSpace, d::Domain) = NormalizedPolynomialSpace(
 NormalizedPolynomialSpace(space::PolynomialSpace{D,R}) where {D,R} = NormalizedPolynomialSpace{typeof(space),D,R}(space)
 
 normalized(S::PolynomialSpace) = NormalizedPolynomialSpace(S)
-normalized(S::PiecewiseSpace{<:NTuple{<:Any,PolynomialSpace}}) = PiecewiseSpace(map(NormalizedPolynomialSpace, components(S)))
+normalized(S::PiecewiseSpace{<:NTuple{<:Any,PolynomialSpace}}) = PiecewiseSpace(map(normalized, components(S)))
 
 supportsinplacetransform(N::NormalizedPolynomialSpace) = supportsinplacetransform(N.space)
 

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -1,4 +1,4 @@
-export PolynomialSpace, NormalizedPolynomialSpace
+export PolynomialSpace, NormalizedPolynomialSpace, normalized
 
 ## Orthogonal polynomials
 
@@ -442,6 +442,9 @@ canonicalspace(S::NormalizedPolynomialSpace) = S.space
 setdomain(NS::NormalizedPolynomialSpace, d::Domain) = NormalizedPolynomialSpace(setdomain(canonicalspace(NS), d))
 
 NormalizedPolynomialSpace(space::PolynomialSpace{D,R}) where {D,R} = NormalizedPolynomialSpace{typeof(space),D,R}(space)
+
+normalized(S::PolynomialSpace) = NormalizedPolynomialSpace(S)
+normalized(S::PiecewiseSpace{<:NTuple{<:Any,PolynomialSpace}}) = PiecewiseSpace(map(NormalizedPolynomialSpace, components(S)))
 
 supportsinplacetransform(N::NormalizedPolynomialSpace) = supportsinplacetransform(N.space)
 

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -1,4 +1,4 @@
-export PolynomialSpace, NormalizedPolynomialSpace, normalized
+export PolynomialSpace, NormalizedPolynomialSpace
 
 ## Orthogonal polynomials
 
@@ -443,8 +443,7 @@ setdomain(NS::NormalizedPolynomialSpace, d::Domain) = NormalizedPolynomialSpace(
 
 NormalizedPolynomialSpace(space::PolynomialSpace{D,R}) where {D,R} = NormalizedPolynomialSpace{typeof(space),D,R}(space)
 
-normalized(S::PolynomialSpace) = NormalizedPolynomialSpace(S)
-normalized(S::PiecewiseSpace{<:NTuple{<:Any,PolynomialSpace}}) = PiecewiseSpace(map(normalized, components(S)))
+normalizedspace(S::PolynomialSpace) = NormalizedPolynomialSpace(S)
 
 supportsinplacetransform(N::NormalizedPolynomialSpace) = supportsinplacetransform(N.space)
 

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -444,6 +444,7 @@ setdomain(NS::NormalizedPolynomialSpace, d::Domain) = NormalizedPolynomialSpace(
 NormalizedPolynomialSpace(space::PolynomialSpace{D,R}) where {D,R} = NormalizedPolynomialSpace{typeof(space),D,R}(space)
 
 normalizedspace(S::PolynomialSpace) = NormalizedPolynomialSpace(S)
+normalizedspace(S::NormalizedPolynomialSpace) = S
 
 supportsinplacetransform(N::NormalizedPolynomialSpace) = supportsinplacetransform(N.space)
 

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -452,5 +452,7 @@ using ApproxFunOrthogonalPolynomials: forwardrecurrence
         g = Conversion(S, NS) * f
         @test g(0.4) ≈ 0.4
         @test g(-0.4) ≈ -0.4
+
+        @test normalizedspace(NS) == NS
     end
 end

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -441,4 +441,16 @@ using ApproxFunOrthogonalPolynomials: forwardrecurrence
         blk = @inferred ApproxFunBase.block(s, 2)
         @test Int(blk) == 1
     end
+
+    @testset "PiecewiseSpace" begin
+        d = Segment(-1..0) ∪ Segment(0..1)
+        S = PiecewiseSpace(Chebyshev.(components(d)))
+        NS = normalized(S)
+        @test domain(NS) == domain(S)
+        @test NS isa PiecewiseSpace{<:NTuple{<:Any,NormalizedChebyshev}}
+        f = Fun(S)
+        g = Conversion(S, NS) * f
+        @test g(0.4) ≈ 0.4
+        @test g(-0.4) ≈ -0.4
+    end
 end

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -445,7 +445,7 @@ using ApproxFunOrthogonalPolynomials: forwardrecurrence
     @testset "PiecewiseSpace" begin
         d = Segment(-1..0) ∪ Segment(0..1)
         S = PiecewiseSpace(Chebyshev.(components(d)))
-        NS = normalized(S)
+        NS = normalizedspace(S)
         @test domain(NS) == domain(S)
         @test NS isa PiecewiseSpace{<:NTuple{<:Any,NormalizedChebyshev}}
         f = Fun(S)


### PR DESCRIPTION
This provides a uniform way to construct normalized spaces over intervals/segments or piecewise domains:
```julia
julia> d = Segment(-1..0)∪Segment(0..1)
the segment [-1.0,0.0] ∪ the segment [0.0,1.0]

julia> S = PiecewiseSpace(Chebyshev.(components(d)))
Chebyshev(the segment [-1.0,0.0]) ⨄ Chebyshev(the segment [0.0,1.0])

julia> normalized(S)
NormalizedChebyshev(the segment [-1.0,0.0]) ⨄ NormalizedChebyshev(the segment [0.0,1.0])

julia> S = Chebyshev(0..1)
Chebyshev(0..1)

julia> normalized(S)
NormalizedChebyshev(0..1)
```