### PR TITLE
Modules in tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ApproxFunBase = "0.8.23"
+ApproxFunBase = "0.8.28"
 ApproxFunBaseTest = "0.1"
 Aqua = "0.6"
 BandedMatrices = "0.16, 0.17"

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -567,14 +567,6 @@ function Multiplication(f::Fun{<:NormalizedPolynomialSpace}, sp::NormalizedPolyn
     Multiplication(fc, sp)
 end
 
-function Derivative(sp::NormalizedPolynomialSpace, k::Number)
-    assert_integer(k)
-    csp=canonicalspace(sp)
-    D = Derivative(csp,k)
-    C = ConcreteConversion(sp,csp)
-    DerivativeWrapper(TimesOperator(D, C), k, sp, rangespace(D))
-end
-
 ApproxFunBase.hasconcreteconversion_canonical(
     @nospecialize(::NormalizedPolynomialSpace), @nospecialize(_)) = true
 

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -1,10 +1,14 @@
+module ChebyshevTest
+
 using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
 using LinearAlgebra
 using Test
-using ApproxFunBase: recA, recB, recC, transform!, itransform!
+using ApproxFunBase: transform!, itransform!
 using ApproxFunBaseTest: testspace
 using ApproxFunOrthogonalPolynomials: forwardrecurrence
+
+include("testutils.jl")
 
 @verbose @testset "Chebyshev" begin
     @testset "Forward recurrence" begin
@@ -456,3 +460,5 @@ using ApproxFunOrthogonalPolynomials: forwardrecurrence
         @test normalizedspace(NS) == NS
     end
 end
+
+end # module

--- a/test/ClenshawTest.jl
+++ b/test/ClenshawTest.jl
@@ -1,3 +1,5 @@
+module ClenshawTest
+
 using ApproxFunOrthogonalPolynomials
 using StaticArrays
 using Test
@@ -6,3 +8,5 @@ using Test
     test_function = Fun(sin, 50)
     @test test_function(0.9) ≈ clenshaw(0.9, SVector{50}(test_function.coefficients))
 end
+
+end # module

--- a/test/ComplexTest.jl
+++ b/test/ComplexTest.jl
@@ -1,6 +1,7 @@
 module ComplexTest
 
 using ApproxFunOrthogonalPolynomials
+using LinearAlgebra
 using Test
 
 @testset "Complex" begin

--- a/test/ComplexTest.jl
+++ b/test/ComplexTest.jl
@@ -1,3 +1,5 @@
+module ComplexTest
+
 using ApproxFunOrthogonalPolynomials
 using Test
 
@@ -27,3 +29,5 @@ using Test
         @test norm(integrate(f)+im*f-f.coefficients[1]*im) < 100eps()
     end
 end
+
+end # module

--- a/test/EigTest.jl
+++ b/test/EigTest.jl
@@ -1,3 +1,5 @@
+module EigTest
+
 using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
 using ApproxFunBase: bandwidth
@@ -177,3 +179,5 @@ using Test
         @test eltype(λ) == Complex{Float64}
     end
 end
+
+end # module

--- a/test/HermiteTest.jl
+++ b/test/HermiteTest.jl
@@ -2,9 +2,10 @@ module HermiteTest
 
 using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
+using ApproxFunBaseTest: testbandedoperator
+using LinearAlgebra
 using SpecialFunctions
 using Test
-using ApproxFunBaseTest: testbandedoperator
 
 @testset "Hermite and GaussWeight" begin
     @testset "Evaluation" begin

--- a/test/HermiteTest.jl
+++ b/test/HermiteTest.jl
@@ -1,3 +1,5 @@
+module HermiteTest
+
 using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
 using SpecialFunctions
@@ -75,3 +77,5 @@ using ApproxFunBaseTest: testbandedoperator
         @test g(1.) ≈ 3.
     end
 end
+
+end # module

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -1,3 +1,5 @@
+module JacobiTest
+
 using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
 using Test
@@ -12,6 +14,8 @@ using StaticArrays: SVector
 using Static
 using HalfIntegers
 using OddEvenIntegers
+
+include("testutils.jl")
 
 @verbose @testset "Jacobi" begin
     @testset "Basic" begin
@@ -694,16 +698,21 @@ using OddEvenIntegers
         @inferred (() -> Integral(Legendre()))()
         @inferred (() -> Integral(Jacobi(1,1)))()
         @inferred (() -> Integral(Jacobi(Ultraspherical(1))))()
-        @testset for sp in (Legendre(), Jacobi(1,1), Jacobi(Ultraspherical(1)))
-            Ij = Integral(sp, 1)
-            @test !isdiag(Ij)
-            f = Fun(sp)
-            g = Ij * f
-            g = Fun(g, sp)
-            g = g - coefficients(g)[1]
-            gexp = Fun(x->x^2/2, sp)
-            gexp = gexp - coefficients(gexp)[1]
-            @test g ≈ gexp
+        @inferred (() -> Integral(NormalizedLegendre()))()
+        @inferred (() -> Integral(NormalizedJacobi(1,1)))()
+        @inferred (() -> Integral(NormalizedJacobi(NormalizedUltraspherical(1))))()
+        for sp in (Legendre(), Jacobi(1,1), Jacobi(Ultraspherical(1)))
+            @testset for _sp in (sp, NormalizedPolynomialSpace(sp))
+                Ij = Integral(_sp, 1)
+                @test !isdiag(Ij)
+                f = Fun(sp)
+                g = Ij * f
+                g = Fun(g, sp)
+                g = g - coefficients(g)[1]
+                gexp = Fun(x->x^2/2, sp)
+                gexp = gexp - coefficients(gexp)[1]
+                @test g ≈ gexp
+            end
         end
 
         @testset for n in 3:6, d in ((), (0..1,)),
@@ -740,3 +749,5 @@ using OddEvenIntegers
         @test ApproxFunBase.hasconversion(Chebyshev()*Legendre(), NormalizedChebyshev()*NormalizedLegendre())
     end
 end
+
+end # module

--- a/test/LaguerreTest.jl
+++ b/test/LaguerreTest.jl
@@ -1,9 +1,12 @@
+module LaguerreTest
+
 using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
 using SpecialFunctions
 using Test
 using ApproxFunBaseTest: testbandedoperator
 
+include("testutils.jl")
 
 @verbose @testset "Laguerre and WeightedLaguerre" begin
     @testset "Ray" begin
@@ -107,3 +110,5 @@ using ApproxFunBaseTest: testbandedoperator
         @test rangespace(M) == LaguerreWeight(-0.5,Laguerre())
     end
 end
+
+end # module

--- a/test/MultivariateTest.jl
+++ b/test/MultivariateTest.jl
@@ -1,3 +1,5 @@
+module MultivariateTest
+
 using ApproxFunBase
 using ApproxFunOrthogonalPolynomials
 using LinearAlgebra
@@ -11,6 +13,8 @@ using ApproxFunOrthogonalPolynomials: chebyshevtransform
 using StaticArrays: SVector
 
 using Base: oneto
+
+include("testutils.jl")
 
 @verbose @testset "Multivariate" begin
     @testset "vectorization order" begin
@@ -563,3 +567,5 @@ using Base: oneto
         @test d2 == (0..1) × (0.0..2.0) × (0..2)
     end
 end
+
+end # module

--- a/test/ODETest.jl
+++ b/test/ODETest.jl
@@ -5,6 +5,7 @@ using ApproxFunBase
 using SpecialFunctions
 using Test
 using LazyArrays
+using LinearAlgebra
 using ApproxFunBase: Multiplication, interlace, ∞, ℵ₀
 using ApproxFunBaseTest: testraggedbelowoperator, testbandedoperator
 

--- a/test/ODETest.jl
+++ b/test/ODETest.jl
@@ -1,3 +1,5 @@
+module ODETest
+
 using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
 using SpecialFunctions
@@ -5,6 +7,8 @@ using Test
 using LazyArrays
 using ApproxFunBase: Multiplication, interlace, ∞, ℵ₀
 using ApproxFunBaseTest: testraggedbelowoperator, testbandedoperator
+
+include("testutils.jl")
 
 @verbose @testset "ODE" begin
     @testset "Airy" begin
@@ -256,3 +260,5 @@ using ApproxFunBaseTest: testraggedbelowoperator, testbandedoperator
         @test norm(F*x-u)<1000eps()
     end
 end
+
+end # module

--- a/test/OperatorTest.jl
+++ b/test/OperatorTest.jl
@@ -1,3 +1,5 @@
+module OperatorTest
+
 using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
 using BlockBandedMatrices
@@ -7,6 +9,8 @@ using ApproxFunBase: Multiplication, InterlaceOperator, Block, ∞
 using ApproxFunBaseTest: testfunctional, testbandedoperator, testraggedbelowoperator,
                         testblockbandedoperator
 using ApproxFunOrthogonalPolynomials: JacobiZ
+
+include("testutils.jl")
 
 @verbose @testset "Operator" begin
     @testset "Evaluation" begin
@@ -314,4 +318,4 @@ using ApproxFunOrthogonalPolynomials: JacobiZ
     end
 end
 
-
+end # module

--- a/test/PDETest.jl
+++ b/test/PDETest.jl
@@ -1,9 +1,13 @@
+module PDETest
+
 using ApproxFunBase
 using ApproxFunOrthogonalPolynomials
 using LinearAlgebra
 using Test
 using ApproxFunBase: Block, ldiv_coefficients
 using ApproxFunBaseTest: testbandedblockbandedoperator, testblockbandedoperator, testraggedbelowoperator
+
+include("testutils.jl")
 
 @verbose @testset "PDE" begin
     @testset "Rectangle Laplace/Poisson" begin
@@ -295,3 +299,5 @@ using ApproxFunBaseTest: testbandedblockbandedoperator, testblockbandedoperator,
         @test u(-0.4,0.1) ≈ u(-0.5,0.0) atol = 0.0001
     end
 end
+
+end # module

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -1,3 +1,5 @@
+module SpacesTest
+
 using ApproxFunOrthogonalPolynomials
 using SpecialFunctions
 using LinearAlgebra
@@ -318,3 +320,5 @@ using ApproxFunBaseTest: testbandedoperator, testraggedbelowoperator,
         @test f(-0.1) ≈ -0.1
     end
 end
+
+end # module

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -1,3 +1,5 @@
+module UltrasphericalTest
+
 using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
 using Test
@@ -6,6 +8,8 @@ using LinearAlgebra
 using Static
 using OddEvenIntegers
 using HalfIntegers
+
+include("testutils.jl")
 
 @verbose @testset "Ultraspherical" begin
     @testset "promotion" begin
@@ -307,3 +311,5 @@ using HalfIntegers
         end
     end
 end
+
+end # module

--- a/test/VectorTest.jl
+++ b/test/VectorTest.jl
@@ -1,3 +1,5 @@
+module VectorTest
+
 using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
 using LazyArrays
@@ -11,6 +13,7 @@ using StaticArrays: SVector
 
 using ApproxFunBaseTest: testblockbandedoperator, testraggedbelowoperator
 
+include("testutils.jl")
 
 @verbose @testset "Vector" begin
     @testset "Construction" begin
@@ -253,3 +256,5 @@ using ApproxFunBaseTest: testblockbandedoperator, testraggedbelowoperator
         @test diagm(0 => [x,x]) * [1,2] == [x,2x]
     end
 end
+
+end # module

--- a/test/broadcastingtest.jl
+++ b/test/broadcastingtest.jl
@@ -1,8 +1,12 @@
+module BroadcastingTest
+
 using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
 using SpecialFunctions
 using LinearAlgebra
 using Test
+
+include("testutils.jl")
 
 @verbose @testset "broadcast" begin
     @testset "Special functions" begin
@@ -65,3 +69,5 @@ using Test
         @test norm.(f,[1,2]) ≈ norm.(F,[1,2]) ≈ [norm(f[1],1),norm(f[2],2)] # isa Vector{Float64}
     end
 end
+
+end #module

--- a/test/showtest.jl
+++ b/test/showtest.jl
@@ -1,4 +1,8 @@
+module ShowTest
+
+using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
+
 @testset "show" begin
 	@test repr(Chebyshev()) == "Chebyshev()"
 	@test repr(NormalizedChebyshev()) == "NormalizedChebyshev()"
@@ -51,3 +55,5 @@ using ApproxFunBase
 		@test contains(String(take!(io)), summarystr)
 	end
 end
+
+end # module

--- a/test/showtest.jl
+++ b/test/showtest.jl
@@ -2,6 +2,7 @@ module ShowTest
 
 using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
+using Test
 
 @testset "show" begin
 	@test repr(Chebyshev()) == "Chebyshev()"


### PR DESCRIPTION
Also, remove the `Derivative` specialization for `NormalizedPolynomialSpace`s, as this isn't necessary on recent versions of `ApproxFunBase`