### PR TITLE
Faster indexing for `Ultraspherical(0.5)` ⟷ `Legendre`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.6.32"
+version = "0.6.33"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -469,6 +469,8 @@ end
 function Conversion(L::NormalizedPolynomialSpace{<:PolynomialSpace},
         M::NormalizedPolynomialSpace{<:PolynomialSpace})
 
+    L == M && return Conversion(L)
+
     C1 = ConcreteConversion(L, canonicalspace(L))
     C2 = Conversion(canonicalspace(L), canonicalspace(M))
     C3 = ConcreteConversion(canonicalspace(M), M)

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -466,6 +466,15 @@ function Conversion(L::S, M::NormalizedPolynomialSpace{S}) where S<:PolynomialSp
     end
 end
 
+function Conversion(L::NormalizedPolynomialSpace{<:PolynomialSpace},
+        M::NormalizedPolynomialSpace{<:PolynomialSpace})
+
+    C1 = ConcreteConversion(L, canonicalspace(L))
+    C2 = Conversion(canonicalspace(L), canonicalspace(M))
+    C3 = ConcreteConversion(canonicalspace(M), M)
+    ConversionWrapper(C3 * C2 * C1, L, M)
+end
+
 function Fun(::typeof(identity), S::NormalizedPolynomialSpace)
     C = canonicalspace(S)
     f = Fun(identity, C)

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -124,7 +124,8 @@ include("testutils.jl")
         end
 
         @testset for (S1, S2) in ((Legendre(), Jacobi(-0.5, -0.5)), (Jacobi(-0.5, -0.5), Legendre()),
-                (Legendre(), Jacobi(1.5, 1.5)))
+                (Legendre(), Jacobi(1.5, 1.5)), (Legendre(), Ultraspherical(0.5)),
+                (Ultraspherical(0.5), Legendre()))
             @test Conversion(S1, S2) * Fun(x->x^4, S1) ≈ Fun(x->x^4, S2)
         end
 
@@ -241,6 +242,30 @@ include("testutils.jl")
             Y = X : Legendre()
             @test domainspace(Y) == Legendre()
             @test Y * Fun(Legendre()) ≈ Fun(x->x^2, Legendre())
+        end
+
+        @testset "getindex for ConcreteConversion" begin
+            for m in (0,1)
+                C = Conversion(Jacobi(m,m), Ultraspherical(m+0.5))
+                @test isdiag(C)
+                B = C[1:10, 1:10]
+                for i in 1:10
+                    @test C[i,i] ≈ B[i,i]
+                end
+
+                C = Conversion(Ultraspherical(m+0.5), Jacobi(m,m))
+                @test isdiag(C)
+                B = C[1:10, 1:10]
+                for i in 1:10
+                    @test C[i,i] ≈ B[i,i]
+                end
+            end
+        end
+
+        @testset "NormalizedJacobi and NormalizedUltraspherical" begin
+            C = Conversion(NormalizedUltraspherical(1.5), NormalizedJacobi(1,1))
+            @test isdiag(C)
+            @test C[1:10, 1:10] ≈ I
         end
     end
 

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -263,9 +263,18 @@ include("testutils.jl")
         end
 
         @testset "NormalizedJacobi and NormalizedUltraspherical" begin
-            C = Conversion(NormalizedUltraspherical(1.5), NormalizedJacobi(1,1))
-            @test isdiag(C)
-            @test C[1:10, 1:10] ≈ I
+            for m in (0,1)
+                C = Conversion(NormalizedUltraspherical(m + 0.5), NormalizedJacobi(m,m))
+                @test isdiag(C)
+                @test C[1:10, 1:10] ≈ I
+            end
+        end
+        @testset "Normalized and Unnormalized" begin
+            C = Conversion(NormalizedUltraspherical(0.5), Legendre())
+            @test C * Fun(x->x^4, NormalizedUltraspherical(0.5)) ≈ Fun(x->x^4, Legendre())
+
+            C = Conversion(Legendre(), NormalizedChebyshev())
+            @test C * Fun(x->x^4, Legendre()) ≈ Fun(x->x^4, NormalizedChebyshev())
         end
     end
 


### PR DESCRIPTION
After this,
```julia
julia> C = Conversion(Ultraspherical(0.5), Legendre());

julia> @btime $C[1:100, 1:100];
  169.329 ns (2 allocations: 944 bytes) # PR
  821.360 ns (6 allocations: 4.42 KiB) # master
```
This also fixes
```julia
julia> Conversion(NormalizedUltraspherical(1.5), NormalizedJacobi(1,1))
ConversionWrapper : NormalizedUltraspherical(1.5) → NormalizedJacobi(1,1)
 1.0000000000000002   ⋅                  …   ⋅                   ⋅   ⋅
  ⋅                  1.0000000000000002      ⋅                   ⋅   ⋅
  ⋅                   ⋅                      ⋅                   ⋅   ⋅
  ⋅                   ⋅                      ⋅                   ⋅   ⋅
  ⋅                   ⋅                      ⋅                   ⋅   ⋅
  ⋅                   ⋅                  …   ⋅                   ⋅   ⋅
  ⋅                   ⋅                      ⋅                   ⋅   ⋅
  ⋅                   ⋅                      ⋅                   ⋅   ⋅
  ⋅                   ⋅                     1.0000000000000004   ⋅   ⋅
  ⋅                   ⋅                      ⋅                  1.0  ⋅
  ⋅                   ⋅                  …   ⋅                   ⋅   ⋱

```