### PR TITLE
Speed-up Chebyshev ldirichlet indexing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.6.34"
+version = "0.6.35"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/src/Spaces/Chebyshev/ChebyshevOperators.jl
+++ b/src/Spaces/Chebyshev/ChebyshevOperators.jl
@@ -84,7 +84,7 @@ function _getindex_eval_leftendpoint(op::ConcreteEvaluation{<:Chebyshev{<:Interv
 
     ret = Array{T}(undef, n)
     for (ind, j) in enumerate(k)
-        ret[ind] = isodd(p+1+j) ? -1 : 1
+        ret[ind] = iseven(p+j) ? -1 : 1
     end
 
     for m in 0:p-1

--- a/src/Spaces/Chebyshev/ChebyshevOperators.jl
+++ b/src/Spaces/Chebyshev/ChebyshevOperators.jl
@@ -84,7 +84,7 @@ function _getindex_eval_leftendpoint(op::ConcreteEvaluation{<:Chebyshev{<:Interv
 
     ret = Array{T}(undef, n)
     for (ind, j) in enumerate(k)
-        ret[ind]=(-1)^(p+1)*(-one(T))^j
+        ret[ind] = isodd(p+1+j) ? -1 : 1
     end
 
     for m in 0:p-1


### PR DESCRIPTION
On master
```julia
julia> D = ldirichlet(Chebyshev());

julia> @btime $D[1:100];
  1.416 μs (1 allocation: 896 bytes)
```
After this
```julia
julia> @btime $D[1:100];
  136.291 ns (1 allocation: 896 bytes)
```