### PR TITLE
Speed up ChebyshevDirichlet leftendpoint indexing

### DIFF
--- a/src/Spaces/Ultraspherical/DirichletSpace.jl
+++ b/src/Spaces/Ultraspherical/DirichletSpace.jl
@@ -191,7 +191,7 @@ function _getindex_eval_leftendpoint(B::ConcreteEvaluation{<:ChebyshevDirichlet{
     S = Space(domain(B))
 
     if B.order == 0
-        eltype(B)[k==1 ? 1.0 : -(-1)^k*2.0 for k=kr]
+        eltype(B)[k==1 ? 1.0 : (iseven(k) ? -2.0 : 2.0) for k=kr]
     else
         _getindex_default(B, x, kr)
     end


### PR DESCRIPTION
On master
```julia
julia> S = ChebyshevDirichlet{0,1}()

julia> @btime Evaluation($S, leftendpoint)[1:100];
  940.091 ns (1 allocation: 896 bytes)
```
This PR
```julia
julia> @btime Evaluation($S, leftendpoint)[1:100];
  76.757 ns (1 allocation: 896 bytes)
```