### PR TITLE
Faster evaluation in normalized spaces

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.6.35"
+version = "0.6.36"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -529,6 +529,20 @@ function getindex(C::ConcreteConversion{S,NormalizedPolynomialSpace{S,D,R},T},k:
     end
 end
 
+function getindex(op::ConcreteEvaluation{<:NormalizedPolynomialSpace}, k::Integer)
+    S = domainspace(op)
+    ec = Evaluation(canonicalspace(S), op.x, op.order)[k]
+    nrm = ConcreteConversion(S, canonicalspace(S))[k,k]
+    nrm * ec
+end
+function getindex(op::ConcreteEvaluation{<:NormalizedPolynomialSpace}, kr::AbstractRange)
+    S = domainspace(op)
+    ec = Evaluation(canonicalspace(S), op.x, op.order)[kr]
+    C = ConcreteConversion(S, canonicalspace(S))
+    nrm = [C[k,k] for k in kr]
+    nrm .* ec
+end
+
 spacescompatible(a::NormalizedPolynomialSpace,b::NormalizedPolynomialSpace) = spacescompatible(a.space,b.space)
 hasconversion(a::PolynomialSpace,b::NormalizedPolynomialSpace) = hasconversion(a,b.space)
 hasconversion(a::NormalizedPolynomialSpace,b::PolynomialSpace) = hasconversion(a.space,b)

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -168,6 +168,14 @@ include("testutils.jl")
                 end
             end
         end
+
+        @testset "Evaluation" begin
+            S = NormalizedUltraspherical(1)
+            E = Evaluation(S, 0.5)
+            @test reshape(E[1:1, 1:10], 10) ≈ [E[1,i] for i in 1:10]
+            f = Fun(x->x^3, S)
+            @test Number(E * f) ≈ f(0.5)
+        end
     end
 
     @testset "inplace transform" begin


### PR DESCRIPTION
This was hitting the fallback method previously, which was slow.
On master
```julia
julia> E = Evaluation(NormalizedUltraspherical(1), 0.5);

julia> @btime $E[1,1];
  2.391 μs (23 allocations: 704 bytes)
```
This PR
```julia
julia> @btime $E[1,1];
  183.369 ns (2 allocations: 128 bytes)
```