### PR TITLE
Make points test approximate

### DIFF
--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -330,7 +330,7 @@ include("testutils.jl")
 
     @testset "values for ArraySpace Fun" begin
         f = Fun(Chebyshev() ⊗ Chebyshev())
-        @test f.(points(f)) == points(f)
+        @test f.(points(f)) ≈ points(f)
         @test values(f) == itransform(space(f), coefficients(f))
         a = transform(space(f), values(f))
         b = coefficients(f)


### PR DESCRIPTION
It's better to test for approximate equality to avoid breakages from changes to floating-point return values. This was one of the failing tests in #273 