### PR TITLE
Use ApproxFunBase.mean instead of Statistics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,6 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [weakdeps]
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"

--- a/src/ApproxFunOrthogonalPolynomials.jl
+++ b/src/ApproxFunOrthogonalPolynomials.jl
@@ -1,7 +1,7 @@
 module ApproxFunOrthogonalPolynomials
 using Base, LinearAlgebra, Reexport, BandedMatrices, BlockBandedMatrices,
             BlockArrays, FillArrays, FastTransforms, IntervalSets,
-            DomainSets, Statistics, SpecialFunctions, FastGaussQuadrature
+            DomainSets, SpecialFunctions, FastGaussQuadrature
 
 @reexport using ApproxFunBase
 
@@ -44,7 +44,8 @@ import ApproxFunBase: Fun, SubSpace, WeightSpace, NoSpace, HeavisideSpace,
                     assert_integer, supportsinplacetransform, ContinuousSpace, SpecialEvalPtType,
                     isleftendpoint, isrightendpoint, evaluation_point, boundaryfn, ldiffbc, rdiffbc,
                     LeftEndPoint, RightEndPoint, normalizedspace, promotedomainspace,
-                    bandmatrices_eigen, SymmetricEigensystem, SkewSymmetricEigensystem
+                    bandmatrices_eigen, SymmetricEigensystem, SkewSymmetricEigensystem,
+                    mean # differs from Statistics.mean after https://github.com/JuliaApproximation/ApproxFunBase.jl/pull/506
 
 import DomainSets: Domain, indomain, UnionDomain, FullSpace, Point,
             Interval, ChebyshevInterval, boundary, rightendpoint, leftendpoint,

--- a/src/Spaces/IntervalSpace.jl
+++ b/src/Spaces/IntervalSpace.jl
@@ -1,7 +1,7 @@
 Space(d::IntervalOrSegment) = Chebyshev(d)
 Space(d::FullSpace{<:Real}) = Chebyshev(Line())
 
-# TODO: mode these functions to ApproxFunBase
+# TODO: move these functions to ApproxFunBase
 function Fun(::typeof(identity), d::IntervalOrSegment{<:Number})
     Fun(Space(d), [mean(d), complexlength(d)/2])
 end


### PR DESCRIPTION
This removes the explicit dependency on Statistics, and these may differ after https://github.com/JuliaApproximation/ApproxFunBase.jl/pull/506