### PR TITLE
conversion/maxspace/union rules for normalized spaces

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.6.44"
+version = "0.6.45"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/src/Spaces/Jacobi/JacobiOperators.jl
+++ b/src/Spaces/Jacobi/JacobiOperators.jl
@@ -511,25 +511,21 @@ end
 
 for (OPrule,OP) in ((:conversion_rule,:conversion_type), (:maxspace_rule,:maxspace))
     @eval begin
-        function $OPrule(A::Chebyshev,B::Jacobi)
+        function $OPrule(A::Chebyshev, B::Jacobi)
             if isapproxminhalf(B.a) && isapproxminhalf(B.b)
                 # the spaces are the same
-                A
-            elseif isapproxhalfoddinteger(B.a) && isapproxhalfoddinteger(B.b)
-                $OP(Jacobi(A),B)
+                B # return the Jacobi for type-stability
             else
-                NoSpace()
+                $OP(Jacobi(A),B)
             end
         end
-        function $OPrule(A::Ultraspherical,B::Jacobi)
+        function $OPrule(A::Ultraspherical, B::Jacobi)
             m = order(A)
             if isapproxminhalf(B.a - m) && isapproxminhalf(B.b - m)
                 # the spaces are the same
-                A
-            elseif isapproxhalfoddinteger(B.a) && isapproxhalfoddinteger(B.b)
-                $OP(Jacobi(A),B)
+                B # return the Jacobi for type-stability
             else
-                NoSpace()
+                $OP(Jacobi(A), B)
             end
         end
     end

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -319,17 +319,6 @@ function BandedMatrix(S::SubOperator{T,ConcreteMultiplication{C,PS,T},
     BandedMatrix(view(Bk2,kr2,jr2))
 end
 
-
-
-
-## All polynomial spaces can be converted provided domains match
-
-isconvertible(a::PolynomialSpace, b::PolynomialSpace) = domain(a) == domain(b)
-union_rule(a::PolynomialSpace{D}, b::PolynomialSpace{D}) where {D} =
-    conversion_type(a, b)
-
-
-
 ## General clenshaw
 clenshaw(sp::PolynomialSpace,c::AbstractVector,x::AbstractArray) = clenshaw(c,x,
                                             ClenshawPlan(promote_type(eltype(c),eltype(x)),sp,length(c),length(x)))
@@ -504,6 +493,16 @@ function maxspace_rule(a::NormalizedPolynomialSpace, b::PolynomialSpace)
     maxspace(a.space, b)
 end
 
+function conversion_rule(a::NormalizedPolynomialSpace, b::NormalizedPolynomialSpace)
+    S = conversion_type(a.space, b.space)
+    S isa NoSpace ? S : NormalizedPolynomialSpace(S)
+end
+
+function maxspace_rule(a::NormalizedPolynomialSpace, b::NormalizedPolynomialSpace)
+    S = maxspace(a.space, b.space)
+    S isa NoSpace ? S : NormalizedPolynomialSpace(S)
+end
+
 bandwidths(C::ConcreteConversion{NormalizedPolynomialSpace{S,D,R},S}) where {S,D,R} = (0, 0)
 bandwidths(C::ConcreteConversion{S,NormalizedPolynomialSpace{S,D,R}}) where {S,D,R} = (0, 0)
 
@@ -583,6 +582,12 @@ function hasconversion(A::MaybeNormalizedTensorSpace{<:P1, <:P2},
     _hasconversion_tensor(factors(A), factors(B))
 end
 
+## All polynomial spaces can be converted provided domains match
+
+isconvertible(a::MaybeNormalized, b::MaybeNormalized) = domain(a) == domain(b)
+union_rule(a::MaybeNormalized{<:PolynomialSpace{D}},
+            b::MaybeNormalized{<:PolynomialSpace{D}}) where {D} =
+    conversion_type(a, b)
 
 function Multiplication(f::Fun{<:PolynomialSpace}, sp::NormalizedPolynomialSpace)
     unnorm_sp = canonicalspace(sp)

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -221,6 +221,15 @@ include("testutils.jl")
 
                 @test (@inferred (() ->
                     conversion_type(NormalizedLegendre(0..1), Legendre(0..1)))()) == Legendre(0..1)
+
+                @test @inferred(conversion_type(NormalizedLegendre(), NormalizedLegendre())) ==
+                            NormalizedLegendre()
+                @test @inferred(conversion_type(NormalizedLegendre(), NormalizedJacobi(1,1))) ==
+                            NormalizedLegendre()
+                @test @inferred(conversion_type(NormalizedLegendre(), NormalizedUltraspherical(Legendre()))) ==
+                            NormalizedLegendre()
+                @test @inferred(conversion_type(NormalizedJacobi(Ultraspherical(1)), NormalizedChebyshev())) ==
+                            NormalizedJacobi(Chebyshev())
             end
 
             @testset "NormalizedPolynomialSpace constructor" begin
@@ -692,6 +701,15 @@ include("testutils.jl")
         @testset "inference in maxspace/conversion_type" begin
             @inferred maxspace(NormalizedLegendre(), Legendre())
             @inferred (()->maxspace(NormalizedLegendre(0..1), Legendre(0..1)))()
+
+            S = @inferred(maxspace(NormalizedLegendre(), NormalizedUltraspherical(Legendre())))
+            @test S == NormalizedLegendre()
+            S = @inferred(maxspace(NormalizedLegendre(), NormalizedLegendre()))
+            @test S == NormalizedLegendre()
+            S = @inferred maxspace(NormalizedUltraspherical(1), NormalizedJacobi(Ultraspherical(2)))
+            @test S == NormalizedJacobi(Ultraspherical(2))
+            S = @inferred maxspace(NormalizedChebyshev(), NormalizedJacobi(Ultraspherical(2)))
+            @test S == NormalizedJacobi(Ultraspherical(2))
         end
     end
 
@@ -795,6 +813,14 @@ include("testutils.jl")
 
         x = @inferred ApproxFunBase.conversion_rule(Jacobi(1,1), Jacobi(2,2))
         @test x == Jacobi(1,1)
+
+        sps = (Legendre(), Jacobi(1,1), Ultraspherical(1), Chebyshev())
+        for S1 in sps, S1n in (S1, NormalizedPolynomialSpace(S1)),
+            S2 in sps, S2n in (S2, NormalizedPolynomialSpace(S2)),
+
+            f = @inferred Fun(S1n) + Fun(S2n)
+            @test f ≈ 2Fun()
+        end
     end
 
     @testset "Tensor space conversions" begin


### PR DESCRIPTION
After this, the following is type-inferred:
```juliap
julia> @inferred Fun(NormalizedLegendre()) + Fun(NormalizedLegendre())
Fun(NormalizedLegendre(), [0.0, 1.63299])
```
The idea is that since polynomial spaces may be converted to each other, the same should also hold for normalized polynomial spaces.