### PR TITLE
Add ConstantSpace test for norm/integrate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ ApproxFunOrthogonalPolynomialsPolynomialsExt = "Polynomials"
 ApproxFunOrthogonalPolynomialsStaticExt = "Static"
 
 [compat]
-ApproxFunBase = "0.9.15"
+ApproxFunBase = "0.8.58, 0.9.15"
 ApproxFunBaseTest = "0.1"
 Aqua = "0.7"
 BandedMatrices = "0.16, 0.17"

--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ ApproxFunOrthogonalPolynomialsPolynomialsExt = "Polynomials"
 ApproxFunOrthogonalPolynomialsStaticExt = "Static"
 
 [compat]
-ApproxFunBase = "0.8.57, 0.9.13"
+ApproxFunBase = "0.9.15"
 ApproxFunBaseTest = "0.1"
 Aqua = "0.7"
 BandedMatrices = "0.16, 0.17"

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -254,6 +254,12 @@ using ApproxFunBaseTest: testbandedoperator, testraggedbelowoperator,
         @test angle(f)(2.0) ≈ 0
     end
 
+    @testset "ConstantSpace" begin
+        f = Fun(3, ConstantSpace(0..1))
+
+        @test norm(f) == 3
+    end
+
     @testset "Jump Locations" begin
         x = Fun(UnionDomain(0..1, 2..3))
         @test length(jumplocations(sign(x))) == 0


### PR DESCRIPTION
Tests the implementation of `norm()` and indirectly `integrate()` for ConstantSpace functionals in ApproxFunBase which was added in https://github.com/JuliaApproximation/ApproxFunBase.jl/pull/595.