### PR TITLE
Disable eltype inference test on v1.10+

### DIFF
--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -325,10 +325,10 @@ include("testutils.jl")
             @test D1 * f1 == D2 * f2
 
             if VERSION < v"1.10-"
-                @inferred (D1 -> eltype(D1 + D1))(D1)
+                ElT = @inferred (D1 -> eltype(D1 + D1))(D1)
                 @test ElT == eltype(D1)
             else
-                @test_broken @inferred (D1 -> eltype(D1 + D1))(D1)
+                @test_broken @inferred((D1 -> eltype(D1 + D1))(D1)) == eltype(D1)
             end
         end
 

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -324,7 +324,12 @@ include("testutils.jl")
             @test f1 == f2
             @test D1 * f1 == D2 * f2
 
-            @test (@inferred (D1 -> eltype(D1 + D1))(D1)) == eltype(D1)
+            ElT = try
+                @inferred (D1 -> eltype(D1 + D1))(D1)
+            catch e
+                return e
+            end
+            @test ElT == eltype(D1) broken=(VERSION >= v"1.10-")
         end
 
         @testset "space promotion" begin

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -324,12 +324,12 @@ include("testutils.jl")
             @test f1 == f2
             @test D1 * f1 == D2 * f2
 
-            ElT = try
+            if VERSION < v"1.10-"
                 @inferred (D1 -> eltype(D1 + D1))(D1)
-            catch e
-                return e
+                @test ElT == eltype(D1)
+            else
+                @test_broken @inferred (D1 -> eltype(D1 + D1))(D1)
             end
-            @test ElT == eltype(D1) broken=(VERSION >= v"1.10-")
         end
 
         @testset "space promotion" begin


### PR DESCRIPTION
Until https://github.com/JuliaLang/julia/issues/50965 is resolved, this test needs to be disabled on Julia v1.10+