### PR TITLE
Update onehotvector tests

### DIFF
--- a/test/MiscAFBTest.jl
+++ b/test/MiscAFBTest.jl
@@ -202,8 +202,8 @@ Base.:(==)(a::UniqueInterval, b::UniqueInterval) = (@assert a.parentinterval == 
 
             @testset "OneHotVector" begin
                 for n in [1, 3, 10_000]
-                    f = Fun(Chebyshev(), [zeros(n-1); 1])
-                    g = ApproxFunBase.basisfunction(Chebyshev(), n)
+                    f = Fun(Chebyshev(), [zeros(n); 1])
+                    g = Chebyshev()(n)
                     @test f == g
                     @test f(0.5) == g(0.5)
                 end


### PR DESCRIPTION
Rely less on `ApproxFunBase` internals