### PR TITLE
Faster evaluate in NormalizedPolynomialSpace for OneElement coeffs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunOrthogonalPolynomials"
 uuid = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
-version = "0.6.52"
+version = "0.6.53"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -329,6 +329,18 @@ include("testutils.jl")
             @test space(1 + Fun(NormalizedChebyshev())) == NormalizedChebyshev()
             @test space(1 + Fun(NormalizedChebyshev(0..1))) == NormalizedChebyshev(0..1)
         end
+
+        @testset "evaluate with OneElement" begin
+            g = NormalizedChebyshev()(3)
+            f = Fun(Chebyshev(), [0,0,0,√(2/π)])
+            @test g(0.1) ≈ f(0.1)
+        end
+
+        @testset "Conversion * OneElement" begin
+            g = Chebyshev()(3)
+            f = Conversion(Chebyshev(), NormalizedChebyshev()) * g
+            @test f ≈ Fun(x->-3x+4x^3, NormalizedChebyshev())
+        end
     end
 
     @testset "Operator exponentiation" begin


### PR DESCRIPTION
On master
```julia
julia> f = NormalizedChebyshev()(3);

julia> @btime $f(0.1);
  272.601 ns (2 allocations: 192 bytes)
```
This PR
```julia
julia> @btime $f(0.1);
  36.979 ns (0 allocations: 0 bytes)
```