### PR TITLE
Concrete derivatives may preserve OneElement coefficients

### DIFF
--- a/src/Spaces/Jacobi/JacobiOperators.jl
+++ b/src/Spaces/Jacobi/JacobiOperators.jl
@@ -2,7 +2,7 @@
 
 # specialize Derivative so that this is type-inferred even without constant propagation
 Derivative(J::MaybeNormalized{<:Jacobi}) = ConcreteDerivative(J,1)
-@inline function _Derivative(J::MaybeNormalized{<:Jacobi}, k::Number)
+@inline function _Derivative(J::Jacobi, k::Number)
     assert_integer(k)
     if k==1
         return ConcreteDerivative(J,1)
@@ -13,10 +13,10 @@ Derivative(J::MaybeNormalized{<:Jacobi}) = ConcreteDerivative(J,1)
     end
 end
 @static if VERSION >= v"1.8"
-    Base.@constprop :aggressive Derivative(J::MaybeNormalized{<:Jacobi}, k::Number) =
+    Base.@constprop :aggressive Derivative(J::Jacobi, k::Number) =
         _Derivative(J, k)
 else
-    Derivative(J::MaybeNormalized{<:Jacobi}, k::Number) = _Derivative(J, k)
+    Derivative(J::Jacobi, k::Number) = _Derivative(J, k)
 end
 
 

--- a/src/Spaces/Jacobi/JacobiOperators.jl
+++ b/src/Spaces/Jacobi/JacobiOperators.jl
@@ -2,7 +2,7 @@
 
 # specialize Derivative so that this is type-inferred even without constant propagation
 Derivative(J::MaybeNormalized{<:Jacobi}) = ConcreteDerivative(J,1)
-@inline function _Derivative(J::Jacobi, k::Number)
+@inline function _Derivative(J::MaybeNormalized{<:Jacobi}, k::Number)
     assert_integer(k)
     if k==1
         return ConcreteDerivative(J,1)
@@ -13,10 +13,10 @@ Derivative(J::MaybeNormalized{<:Jacobi}) = ConcreteDerivative(J,1)
     end
 end
 @static if VERSION >= v"1.8"
-    Base.@constprop :aggressive Derivative(J::Jacobi, k::Number) =
+    Base.@constprop :aggressive Derivative(J::MaybeNormalized{<:Jacobi}, k::Number) =
         _Derivative(J, k)
 else
-    Derivative(J::Jacobi, k::Number) = _Derivative(J, k)
+    Derivative(J::MaybeNormalized{<:Jacobi}, k::Number) = _Derivative(J, k)
 end
 
 

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -3,6 +3,7 @@ module ChebyshevTest
 using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
 using DualNumbers
+using FillArrays
 using LinearAlgebra
 using Test
 using ApproxFunBase: transform!, itransform!
@@ -352,20 +353,31 @@ include("testutils.jl")
             f = Conversion(Chebyshev(), NormalizedChebyshev()) * g
             @test f ≈ Fun(x->-3x+4x^3, NormalizedChebyshev())
             @test space(f) == NormalizedChebyshev()
+            if coefficients(g) isa OneElement
+                @test coefficients(f) isa OneElement
+            end
 
             g = NormalizedChebyshev()(3)
             f = Conversion(NormalizedChebyshev(), Chebyshev()) * g
             @test f ≈ g
             @test space(f) == Chebyshev()
+            if coefficients(g) isa OneElement
+                @test coefficients(f) isa OneElement
+            end
         end
 
         @testset "Derivative * OneElement" begin
             g = Chebyshev()(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
-            @test Derivative() * g === 3 * Ultraspherical(1)(2)
+            if coefficients(g) isa OneElement
+                @test coefficients(Derivative() * g) isa OneElement
+            end
 
             g = NormalizedChebyshev()(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
+            if coefficients(g) isa OneElement
+                @test coefficients(Derivative() * g) isa OneElement
+            end
         end
     end
 

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -351,6 +351,21 @@ include("testutils.jl")
             g = Chebyshev()(3)
             f = Conversion(Chebyshev(), NormalizedChebyshev()) * g
             @test f ≈ Fun(x->-3x+4x^3, NormalizedChebyshev())
+            @test space(f) == NormalizedChebyshev()
+
+            g = NormalizedChebyshev()(3)
+            f = Conversion(NormalizedChebyshev(), Chebyshev()) * g
+            @test f ≈ g
+            @test space(f) == Chebyshev()
+        end
+
+        @testset "Derivative * OneElement" begin
+            g = Chebyshev()(3)
+            @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
+            @test Derivative() * g === 3 * Ultraspherical(1)(2)
+
+            g = NormalizedChebyshev()(3)
+            @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
         end
     end
 

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -353,30 +353,38 @@ include("testutils.jl")
             f = Conversion(Chebyshev(), NormalizedChebyshev()) * g
             @test f ≈ Fun(x->-3x+4x^3, NormalizedChebyshev())
             @test space(f) == NormalizedChebyshev()
-            if coefficients(g) isa OneElement
-                @test coefficients(f) isa OneElement
+            @static if isdefined(FillArrays, :OneElement)
+                if coefficients(g) isa OneElement
+                    @test coefficients(f) isa OneElement
+                end
             end
 
             g = NormalizedChebyshev()(3)
             f = Conversion(NormalizedChebyshev(), Chebyshev()) * g
             @test f ≈ g
             @test space(f) == Chebyshev()
-            if coefficients(g) isa OneElement
-                @test coefficients(f) isa OneElement
+            @static if isdefined(FillArrays, :OneElement)
+                if coefficients(g) isa OneElement
+                    @test coefficients(f) isa OneElement
+                end
             end
         end
 
         @testset "Derivative * OneElement" begin
             g = Chebyshev()(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
-            if coefficients(g) isa OneElement
-                @test coefficients(Derivative() * g) isa OneElement
+            @static if isdefined(FillArrays, :OneElement)
+                if coefficients(g) isa OneElement
+                    @test coefficients(Derivative() * g) isa OneElement
+                end
             end
 
             g = NormalizedChebyshev()(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
-            if coefficients(g) isa OneElement
-                @test coefficients(Derivative() * g) isa OneElement
+            @static if isdefined(FillArrays, :OneElement)
+                if coefficients(g) isa OneElement
+                    @test coefficients(Derivative() * g) isa OneElement
+                end
             end
         end
     end

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -757,6 +757,32 @@ include("testutils.jl")
             S = @inferred maxspace(NormalizedChebyshev(), NormalizedJacobi(Ultraspherical(2)))
             @test S == NormalizedJacobi(Ultraspherical(2))
         end
+
+        @testset "Conversion * OneElement" begin
+            g = Legendre()(3)
+            f = Conversion(Legendre(), NormalizedLegendre()) * g
+            @test f ≈ g
+            @test space(f) == NormalizedLegendre()
+
+            g = NormalizedLegendre()(3)
+            f = Conversion(NormalizedLegendre(), Legendre()) * g
+            @test f ≈ g
+            @test space(f) == Legendre()
+        end
+
+        @testset "Derivative * OneElement" begin
+            g = Legendre()(3)
+            @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
+
+            g = Jacobi(1,2)(3)
+            @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
+
+            g = NormalizedLegendre()(3)
+            @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
+
+            g = NormalizedJacobi(1,2)(3)
+            @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
+        end
     end
 
     @testset "casting bug ApproxFun.jl#770" begin

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -774,26 +774,34 @@ include("testutils.jl")
         @testset "Derivative * OneElement" begin
             g = Legendre()(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
-            if coefficients(g) isa OneElement
-                @test coefficients(Derivative() * g) isa OneElement
+            @static if isdefined(FillArrays, :OneElement)
+                if coefficients(g) isa OneElement
+                    @test coefficients(Derivative() * g) isa OneElement
+                end
             end
 
             g = Jacobi(1.5,2)(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
-            if coefficients(g) isa OneElement
-                @test coefficients(Derivative() * g) isa OneElement
+            @static if isdefined(FillArrays, :OneElement)
+                if coefficients(g) isa OneElement
+                    @test coefficients(Derivative() * g) isa OneElement
+                end
             end
 
             g = NormalizedLegendre()(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
-            if coefficients(g) isa OneElement
-                @test_broken coefficients(Derivative() * g) isa OneElement
+            @static if isdefined(FillArrays, :OneElement)
+                if coefficients(g) isa OneElement
+                    @test_broken coefficients(Derivative() * g) isa OneElement
+                end
             end
 
             g = NormalizedJacobi(1,2.5)(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
-            if coefficients(g) isa OneElement
-                @test_broken coefficients(Derivative() * g) isa OneElement
+            @static if isdefined(FillArrays, :OneElement)
+                if coefficients(g) isa OneElement
+                    @test_broken coefficients(Derivative() * g) isa OneElement
+                end
             end
         end
     end

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -2,9 +2,6 @@ module JacobiTest
 
 using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
-using Test
-using SpecialFunctions
-using LinearAlgebra
 using ApproxFunBase: maxspace, NoSpace, hasconversion,
                     reverseorientation, ReverseOrientation, transform!, itransform!
 using ApproxFunBaseTest: testbandedbelowoperator, testbandedoperator, testspace, testtransforms,
@@ -14,10 +11,14 @@ using BandedMatrices
 using BandedMatrices: isbanded
 using BlockArrays
 using BlockBandedMatrices
+using FillArrays
+using HalfIntegers
+using LinearAlgebra
+using OddEvenIntegers
+using SpecialFunctions
 using StaticArrays: SVector
 using Static
-using HalfIntegers
-using OddEvenIntegers
+using Test
 
 include("testutils.jl")
 
@@ -777,14 +778,23 @@ include("testutils.jl")
                 @test coefficients(Derivative() * g) isa OneElement
             end
 
-            g = Jacobi(1,2)(3)
+            g = Jacobi(1.5,2)(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
+            if coefficients(g) isa OneElement
+                @test coefficients(Derivative() * g) isa OneElement
+            end
 
             g = NormalizedLegendre()(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
+            if coefficients(g) isa OneElement
+                @test coefficients(Derivative() * g) isa OneElement
+            end
 
-            g = NormalizedJacobi(1,2)(3)
+            g = NormalizedJacobi(1,2.5)(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
+            if coefficients(g) isa OneElement
+                @test coefficients(Derivative() * g) isa OneElement
+            end
         end
     end
 

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -787,13 +787,13 @@ include("testutils.jl")
             g = NormalizedLegendre()(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
             if coefficients(g) isa OneElement
-                @test coefficients(Derivative() * g) isa OneElement
+                @test_broken coefficients(Derivative() * g) isa OneElement
             end
 
             g = NormalizedJacobi(1,2.5)(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
             if coefficients(g) isa OneElement
-                @test coefficients(Derivative() * g) isa OneElement
+                @test_broken coefficients(Derivative() * g) isa OneElement
             end
         end
     end

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -773,6 +773,9 @@ include("testutils.jl")
         @testset "Derivative * OneElement" begin
             g = Legendre()(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
+            if coefficients(g) isa OneElement
+                @test coefficients(Derivative() * g) isa OneElement
+            end
 
             g = Jacobi(1,2)(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))

--- a/test/MiscAFBTest.jl
+++ b/test/MiscAFBTest.jl
@@ -257,7 +257,7 @@ Base.:(==)(a::UniqueInterval, b::UniqueInterval) = (@assert a.parentinterval == 
                 for ST in Any[Chebyshev, Legendre,
                         (x...) -> Jacobi(2,2,x...), (x...) -> Jacobi(1.5,2.5,x...)]
                     S1 = ST(d...)
-                    for S in [S1, NormalizedPolynomialSpace(S1)]
+                    @testset for S in [S1, NormalizedPolynomialSpace(S1)]
                         @test Derivative(S) == Derivative(S,1)
                         @test Derivative(S)^2 == Derivative(S,2)
                         f = Fun(x->x^3, S)

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -304,19 +304,31 @@ include("testutils.jl")
             f = Conversion(Ultraspherical(3), NormalizedUltraspherical(3)) * g
             @test f ≈ g
             @test space(f) == NormalizedUltraspherical(3)
+            if coefficients(g) isa OneElement
+                @test coefficients(f) isa OneElement
+            end
 
             g = NormalizedUltraspherical(3)(3)
             f = Conversion(NormalizedUltraspherical(3), Ultraspherical(3)) * g
             @test f ≈ g
             @test space(f) == Ultraspherical(3)
+            if coefficients(g) isa OneElement
+                @test coefficients(f) isa OneElement
+            end
         end
 
         @testset "Derivative * OneElement" begin
             g = Ultraspherical(3)(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
+            if coefficients(g) isa OneElement
+                @test coefficients(Derivative() * g) isa OneElement
+            end
 
             g = NormalizedUltraspherical(3)(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
+            if coefficients(g) isa OneElement
+                @test coefficients(Derivative() * g) isa OneElement
+            end
         end
     end
 

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -305,30 +305,38 @@ include("testutils.jl")
             f = Conversion(Ultraspherical(3), NormalizedUltraspherical(3)) * g
             @test f ≈ g
             @test space(f) == NormalizedUltraspherical(3)
-            if coefficients(g) isa OneElement
-                @test coefficients(f) isa OneElement
+            @static if isdefined(FillArrays, :OneElement)
+                if coefficients(g) isa OneElement
+                    @test coefficients(f) isa OneElement
+                end
             end
 
             g = NormalizedUltraspherical(3)(3)
             f = Conversion(NormalizedUltraspherical(3), Ultraspherical(3)) * g
             @test f ≈ g
             @test space(f) == Ultraspherical(3)
-            if coefficients(g) isa OneElement
-                @test coefficients(f) isa OneElement
+            @static if isdefined(FillArrays, :OneElement)
+                if coefficients(g) isa OneElement
+                    @test coefficients(f) isa OneElement
+                end
             end
         end
 
         @testset "Derivative * OneElement" begin
             g = Ultraspherical(3)(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
-            if coefficients(g) isa OneElement
-                @test coefficients(Derivative() * g) isa OneElement
+            @static if isdefined(FillArrays, :OneElement)
+                if coefficients(g) isa OneElement
+                    @test coefficients(Derivative() * g) isa OneElement
+                end
             end
 
             g = NormalizedUltraspherical(3)(3)
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
-            if coefficients(g) isa OneElement
-                @test coefficients(Derivative() * g) isa OneElement
+            @static if isdefined(FillArrays, :OneElement)
+                if coefficients(g) isa OneElement
+                    @test coefficients(Derivative() * g) isa OneElement
+                end
             end
         end
     end

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -298,6 +298,26 @@ include("testutils.jl")
             E = Evaluation(S, 0.5, 2)
             @test Number(E * f) ≈ 6 * (0.5)
         end
+
+        @testset "Conversion * OneElement" begin
+            g = Ultraspherical(3)(3)
+            f = Conversion(Ultraspherical(3), NormalizedUltraspherical(3)) * g
+            @test f ≈ g
+            @test space(f) == NormalizedUltraspherical(3)
+
+            g = NormalizedUltraspherical(3)(3)
+            f = Conversion(NormalizedUltraspherical(3), Ultraspherical(3)) * g
+            @test f ≈ g
+            @test space(f) == Ultraspherical(3)
+        end
+
+        @testset "Derivative * OneElement" begin
+            g = Ultraspherical(3)(3)
+            @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
+
+            g = NormalizedUltraspherical(3)(3)
+            @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
+        end
     end
 
     @testset "inplace transform" begin

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -4,6 +4,7 @@ using ApproxFunOrthogonalPolynomials
 using ApproxFunBase
 using BandedMatrices
 using BandedMatrices: isbanded
+using FillArrays
 using HalfIntegers
 using LinearAlgebra
 using OddEvenIntegers


### PR DESCRIPTION
After this,
```julia
julia> g = Derivative() * Chebyshev()(3)
Fun(Ultraspherical(1), [0.0, 0.0, 3.0])

julia> coefficients(g)
3-element FillArrays.OneElement{Float64, 1, Tuple{Int64}, Tuple{Base.OneTo{Int64}}}:
  ⋅ 
  ⋅ 
 3.0
```