### PR TITLE
Concrete derivative in Jacobi space

### DIFF
--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -792,7 +792,7 @@ include("testutils.jl")
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
             @static if isdefined(FillArrays, :OneElement)
                 if coefficients(g) isa OneElement
-                    @test_broken coefficients(Derivative() * g) isa OneElement
+                    @test coefficients(Derivative() * g) isa OneElement
                 end
             end
 
@@ -800,7 +800,7 @@ include("testutils.jl")
             @test Derivative() * g == Derivative() * Fun(space(g), collect(coefficients(g)))
             @static if isdefined(FillArrays, :OneElement)
                 if coefficients(g) isa OneElement
-                    @test_broken coefficients(Derivative() * g) isa OneElement
+                    @test coefficients(Derivative() * g) isa OneElement
                 end
             end
         end

--- a/test/MiscAFBTest.jl
+++ b/test/MiscAFBTest.jl
@@ -253,21 +253,6 @@ Base.:(==)(a::UniqueInterval, b::UniqueInterval) = (@assert a.parentinterval == 
 
         @testset "Derivative" begin
             @test Derivative() == Derivative()
-            for d in Any[(), (0..1,)]
-                for ST in Any[Chebyshev, Legendre,
-                        (x...) -> Jacobi(2,2,x...), (x...) -> Jacobi(1.5,2.5,x...)]
-                    S1 = ST(d...)
-                    @testset for S in [S1, NormalizedPolynomialSpace(S1)]
-                        @test Derivative(S) == Derivative(S,1)
-                        @test Derivative(S)^2 == Derivative(S,2)
-                        f = Fun(x->x^3, S)
-                        @test Derivative(S) * f ≈ Fun(x->3x^2, S)
-                        @test Derivative(S,2) * f ≈ Fun(x->6x, S)
-                        @test Derivative(S,3) * f ≈ Fun(x->6, S)
-                        @test Derivative(S,4) * f ≈ zeros(S)
-                    end
-                end
-            end
             @test Derivative(Chebyshev()) != Derivative(Chebyshev(), 2)
             @test Derivative(Chebyshev()) != Derivative(Legendre())
         end


### PR DESCRIPTION
With this, higher-order derivatives in a Jacobi space become concrete instead of being wrappers:
```julia
julia> Derivative(Legendre(), 2)
ConcreteDerivative : Legendre() → Jacobi(2,2)
  ⋅    ⋅   3.0   ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
  ⋅    ⋅    ⋅   5.0   ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅   7.5    ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅   10.5    ⋅     ⋅     ⋅     ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅     ⋅   14.0    ⋅     ⋅     ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅   18.0    ⋅     ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅   22.5    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅   27.5  ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅

julia> Derivative(NormalizedLegendre(), 2)
ConcreteDerivative : NormalizedLegendre() → Jacobi(2,2)
  ⋅    ⋅   4.74342   ⋅         ⋅        ⋅        ⋅        ⋅       ⋅        ⋅      ⋅
  ⋅    ⋅    ⋅       9.35414    ⋅        ⋅        ⋅        ⋅       ⋅        ⋅      ⋅
  ⋅    ⋅    ⋅        ⋅       15.9099    ⋅        ⋅        ⋅       ⋅        ⋅      ⋅
  ⋅    ⋅    ⋅        ⋅         ⋅      24.6247    ⋅        ⋅       ⋅        ⋅      ⋅
  ⋅    ⋅    ⋅        ⋅         ⋅        ⋅      35.6931    ⋅       ⋅        ⋅      ⋅
  ⋅    ⋅    ⋅        ⋅         ⋅        ⋅        ⋅      49.295    ⋅        ⋅      ⋅
  ⋅    ⋅    ⋅        ⋅         ⋅        ⋅        ⋅        ⋅     65.5982    ⋅      ⋅
  ⋅    ⋅    ⋅        ⋅         ⋅        ⋅        ⋅        ⋅       ⋅      84.7607  ⋅
  ⋅    ⋅    ⋅        ⋅         ⋅        ⋅        ⋅        ⋅       ⋅        ⋅      ⋱
  ⋅    ⋅    ⋅        ⋅         ⋅        ⋅        ⋅        ⋅       ⋅        ⋅      ⋅
  ⋅    ⋅    ⋅        ⋅         ⋅        ⋅        ⋅        ⋅       ⋅        ⋅      ⋅
```