### PR TITLE
Fix method signature in BandedMatrix for Ultraspherical derivative

### DIFF
--- a/src/fastops.jl
+++ b/src/fastops.jl
@@ -98,7 +98,7 @@ function BandedMatrix(S::SubOperator{T,<:ConcreteDerivative{<:Chebyshev,<:Any,T}
 end
 
 
-function BandedMatrix(S::SubOperator{T,<:ConcreteDerivative{<:Ultraspherical,T},
+function BandedMatrix(S::SubOperator{T,<:ConcreteDerivative{<:Ultraspherical,<:Any,T},
                                                   NTuple{2,UnitRange{Int}}}) where {T}
     n,m = size(S)
     ret = BandedMatrix{eltype(S)}(undef, (n,m), bandwidths(S))

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -304,7 +304,7 @@ include("testutils.jl")
             @test s1 == s2
 
             D1 = @inferred Derivative(s1)
-            D2 = Derivative(s2)
+            D2 = @inferred Derivative(s2)
 
             @test D1 isa ApproxFunBase.ConcreteDerivative
             @test D2 isa ApproxFunBase.ConcreteDerivative

--- a/test/UltrasphericalTest.jl
+++ b/test/UltrasphericalTest.jl
@@ -442,20 +442,19 @@ include("testutils.jl")
         @test M * f ≈ f2
     end
 
+    @testset "Derivative" begin
+        f = Fun(x -> 3x^3 + 4x + 5, Ultraspherical(2))
+        @test Derivative() * f ≈ Fun(x -> 9x^2 + 4, Ultraspherical(2))
+    end
+
     @testset "Derivative in a normalized space" begin
         s1 = NormalizedUltraspherical(1,-1..1)
         s2 = NormalizedUltraspherical(1)
         @test s1 == s2
-        D1 = if VERSION >= v"1.8"
-            @inferred Derivative(s1)
-        else
-            Derivative(s1)
-        end
-        D2 = if VERSION >= v"1.8"
-            @inferred Derivative(s2)
-        else
-            Derivative(s2)
-        end
+
+        D1 = @inferred Derivative(s1)
+        D2 = @inferred Derivative(s2)
+
         @test D1 isa ApproxFunBase.ConcreteDerivative
         @test D2 isa ApproxFunBase.ConcreteDerivative
         @test !isdiag(D1)


### PR DESCRIPTION
With this, the fast method is used to construct a `BandedMatrix` when indexing into a `Derivative` in an `Ultraspherical` space:
```julia
julia> @btime Derivative(Ultraspherical(1))[1:100, 1:100];
  188.008 ns (1 allocation: 896 bytes)
```