### PR TITLE
Disable `macOS-latest` tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-          - macOS-latest
+          # - macOS-latest # FastTransforms.jl is broken on macOS-latest
           # - windows-latest
         arch:
           - x64


### PR DESCRIPTION
The test failures arise from `FastTransforms.jl` being broken on `macOS-latest`, and we may re-enable these tests when the breakages are fixed.